### PR TITLE
Query params Passthrough added to hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direktiv-react-hooks",
-  "version": "0.0.102",
+  "version": "0.0.106",
   "description": "A custom react hook library to talk to direktiv",
   "author": "direktiv",
   "license": "MIT",

--- a/src/event-configuration/index.js
+++ b/src/event-configuration/index.js
@@ -21,7 +21,7 @@ export const useDirektivBroadcastConfiguration = (url, namespace, apikey) => {
 
     async function getBroadcastConfiguration(...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/config${ExtractQueryString(false, queryParameters)}`,{})
+            let resp = await fetch(`${url}namespaces/${namespace}/config${ExtractQueryString(false, ...queryParameters)}`,{})
             if(!resp.ok) {
                 await HandleError('fetch config', resp, 'getNamespaceConfiguration')
             } else {
@@ -35,7 +35,7 @@ export const useDirektivBroadcastConfiguration = (url, namespace, apikey) => {
 
     async function setBroadcastConfiguration(newconfig, ...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/config${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/config${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "PATCH",
                 body: newconfig
             })

--- a/src/event-configuration/index.js
+++ b/src/event-configuration/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { HandleError } from '../util'
+import { HandleError, ExtractQueryString } from '../util'
 const fetch = require('isomorphic-fetch')
 
 /*
@@ -19,9 +19,9 @@ export const useDirektivBroadcastConfiguration = (url, namespace, apikey) => {
         }
     },[data])
 
-    async function getBroadcastConfiguration() {
+    async function getBroadcastConfiguration(...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/config`,{})
+            let resp = await fetch(`${url}namespaces/${namespace}/config${ExtractQueryString(false, queryParameters)}`,{})
             if(!resp.ok) {
                 await HandleError('fetch config', resp, 'getNamespaceConfiguration')
             } else {
@@ -33,9 +33,9 @@ export const useDirektivBroadcastConfiguration = (url, namespace, apikey) => {
         }
     }
 
-    async function setBroadcastConfiguration(newconfig) {
+    async function setBroadcastConfiguration(newconfig, ...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/config`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/config${ExtractQueryString(false, queryParameters)}`, {
                 method: "PATCH",
                 body: newconfig
             })

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -93,9 +93,9 @@ export const useDirektivEvents = (url, stream, namespace, apikey) => {
         return () => CloseEventSource(eventSource)
     },[eventSource])
 
-    async function getEventListeners(){
+    async function getEventListeners(...queryParameters){
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/event-listeners`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/event-listeners${ExtractQueryString(false, queryParameters)}`,{
                 method: "GET",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
@@ -107,9 +107,9 @@ export const useDirektivEvents = (url, stream, namespace, apikey) => {
         }
     }
 
-    async function getEventHistory(){
+    async function getEventHistory(...queryParameters){
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/events`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/events${ExtractQueryString(false, queryParameters)}`,{
                 method: "GET",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
@@ -121,7 +121,7 @@ export const useDirektivEvents = (url, stream, namespace, apikey) => {
         }
     }
 
-    async function replayEvent(event){
+    async function replayEvent(event,...queryParameters){
         let headers = {
             "content-type": "application/cloudevents+json; charset=UTF-8"
         }
@@ -129,7 +129,7 @@ export const useDirektivEvents = (url, stream, namespace, apikey) => {
             headers["apikey"] = apikey
         }
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/events/${event}/replay`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/events/${event}/replay${ExtractQueryString(false, queryParameters)}`,{
                 method: "POST",
                 headers: headers
             })
@@ -141,7 +141,7 @@ export const useDirektivEvents = (url, stream, namespace, apikey) => {
         }
     }
 
-    async function sendEvent(event){
+    async function sendEvent(event,...queryParameters){
         let headers = {
             "content-type": "application/cloudevents+json; charset=UTF-8"
         }
@@ -149,7 +149,7 @@ export const useDirektivEvents = (url, stream, namespace, apikey) => {
             headers["apikey"] = apikey
         }
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/broadcast`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/broadcast${ExtractQueryString(false, queryParameters)}`,{
                 method: "POST",
                 body: event,
                 headers: headers

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -95,7 +95,7 @@ export const useDirektivEvents = (url, stream, namespace, apikey) => {
 
     async function getEventListeners(...queryParameters){
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/event-listeners${ExtractQueryString(false, queryParameters)}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/event-listeners${ExtractQueryString(false, ...queryParameters)}`,{
                 method: "GET",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
@@ -109,7 +109,7 @@ export const useDirektivEvents = (url, stream, namespace, apikey) => {
 
     async function getEventHistory(...queryParameters){
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/events${ExtractQueryString(false, queryParameters)}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/events${ExtractQueryString(false, ...queryParameters)}`,{
                 method: "GET",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
@@ -129,7 +129,7 @@ export const useDirektivEvents = (url, stream, namespace, apikey) => {
             headers["apikey"] = apikey
         }
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/events/${event}/replay${ExtractQueryString(false, queryParameters)}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/events/${event}/replay${ExtractQueryString(false, ...queryParameters)}`,{
                 method: "POST",
                 headers: headers
             })
@@ -149,7 +149,7 @@ export const useDirektivEvents = (url, stream, namespace, apikey) => {
             headers["apikey"] = apikey
         }
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/broadcast${ExtractQueryString(false, queryParameters)}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/broadcast${ExtractQueryString(false, ...queryParameters)}`,{
                 method: "POST",
                 body: event,
                 headers: headers

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { CloseEventSource, HandleError } from '../util'
+import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 const fetch = require('isomorphic-fetch')
 

--- a/src/instance/index.js
+++ b/src/instance/index.js
@@ -61,10 +61,10 @@ export const useDirektivInstanceLogs = (url, stream, namespace, instance, apikey
     },[eventSource])
 
     // getInstanceLogs returns a list of logs
-    async function getInstanceLogs() {
+    async function getInstanceLogs(...queryParameters) {
         try {
             // fetch instance list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/logs`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/logs${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok){
@@ -136,10 +136,10 @@ export const useDirektivInstance = (url, stream, namespace, instance, apikey) =>
     },[eventSource])
 
     // getInstance returns a list of instances
-    async function getInstance() {
+    async function getInstance(...queryParameters) {
         try {
             // fetch instance list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok){
@@ -153,9 +153,9 @@ export const useDirektivInstance = (url, stream, namespace, instance, apikey) =>
         }
     }
 
-    async function getInput() {
+    async function getInput(...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/input`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/input${ExtractQueryString(false, queryParameters)}`, {
                 method:"GET",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
 
@@ -171,9 +171,9 @@ export const useDirektivInstance = (url, stream, namespace, instance, apikey) =>
         }
     }
 
-    async function getOutput(){
+    async function getOutput(...queryParameters){
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/output`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/output${ExtractQueryString(false, queryParameters)}`, {
                 method:"GET",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
 
@@ -189,9 +189,9 @@ export const useDirektivInstance = (url, stream, namespace, instance, apikey) =>
         }
     }
 
-    async function cancelInstance() {
+    async function cancelInstance(...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/cancel`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/cancel${ExtractQueryString(false, queryParameters)}`, {
                 method:"POST",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
 

--- a/src/instance/index.js
+++ b/src/instance/index.js
@@ -64,7 +64,7 @@ export const useDirektivInstanceLogs = (url, stream, namespace, instance, apikey
     async function getInstanceLogs(...queryParameters) {
         try {
             // fetch instance list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/logs${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/logs${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok){
@@ -139,7 +139,7 @@ export const useDirektivInstance = (url, stream, namespace, instance, apikey) =>
     async function getInstance(...queryParameters) {
         try {
             // fetch instance list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok){
@@ -155,7 +155,7 @@ export const useDirektivInstance = (url, stream, namespace, instance, apikey) =>
 
     async function getInput(...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/input${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/input${ExtractQueryString(false, ...queryParameters)}`, {
                 method:"GET",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
 
@@ -173,7 +173,7 @@ export const useDirektivInstance = (url, stream, namespace, instance, apikey) =>
 
     async function getOutput(...queryParameters){
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/output${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/output${ExtractQueryString(false, ...queryParameters)}`, {
                 method:"GET",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
 
@@ -191,7 +191,7 @@ export const useDirektivInstance = (url, stream, namespace, instance, apikey) =>
 
     async function cancelInstance(...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/cancel${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/cancel${ExtractQueryString(false, ...queryParameters)}`, {
                 method:"POST",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
 

--- a/src/instance/index.js
+++ b/src/instance/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { CloseEventSource, HandleError } from '../util'
+import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 const fetch = require('isomorphic-fetch')
 

--- a/src/instances/index.js
+++ b/src/instances/index.js
@@ -57,7 +57,7 @@ export const useDirektivInstances = (url, stream, namespace, apikey) => {
     async function getInstances(...queryParameters) {
         try {
             // fetch instance list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/instances${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/instances${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok){

--- a/src/instances/index.js
+++ b/src/instances/index.js
@@ -54,10 +54,10 @@ export const useDirektivInstances = (url, stream, namespace, apikey) => {
 
 
     // getInstances returns a list of instances
-    async function getInstances() {
+    async function getInstances(...queryParameters) {
         try {
             // fetch instance list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/instances`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/instances${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok){

--- a/src/instances/index.js
+++ b/src/instances/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { CloseEventSource, HandleError } from '../util'
+import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const fetch = require('isomorphic-fetch')
 const {EventSourcePolyfill} = require('event-source-polyfill')
 

--- a/src/jqplayground/index.js
+++ b/src/jqplayground/index.js
@@ -96,7 +96,7 @@ export const useDirektivJQPlayground = (url, apikey) => {
     async function executeJQ(query, data,...queryParameters) {
         try {
             // fetch namespace list by default
-            let resp = await fetch(`${url}jq${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}jq${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "POST",
                 body: JSON.stringify({

--- a/src/jqplayground/index.js
+++ b/src/jqplayground/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 const fetch = require('isomorphic-fetch')
-import { HandleError } from '../util'
+import { HandleError, ExtractQueryString } from '../util'
 
 
 const cheatSheetMap = [

--- a/src/jqplayground/index.js
+++ b/src/jqplayground/index.js
@@ -93,10 +93,10 @@ export const useDirektivJQPlayground = (url, apikey) => {
     const [err, setErr] = React.useState(null)
 
 
-    async function executeJQ(query, data) {
+    async function executeJQ(query, data,...queryParameters) {
         try {
             // fetch namespace list by default
-            let resp = await fetch(`${url}jq`, {
+            let resp = await fetch(`${url}jq${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "POST",
                 body: JSON.stringify({

--- a/src/namespaces/dependencies.js
+++ b/src/namespaces/dependencies.js
@@ -15,10 +15,10 @@ export const useDirektivNamespaceDependencies = (url, namespace, apikey) => {
         }
     },[data])
 
-    async function getNamespaceDependencies() {
+    async function getNamespaceDependencies(...queryParameters) {
         try {
             // fetch namespace list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/dependencies`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/dependencies${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {

--- a/src/namespaces/dependencies.js
+++ b/src/namespaces/dependencies.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { HandleError } from '../util'
+import { HandleError, ExtractQueryString } from '../util'
 const fetch = require('isomorphic-fetch')
 
 

--- a/src/namespaces/dependencies.js
+++ b/src/namespaces/dependencies.js
@@ -18,7 +18,7 @@ export const useDirektivNamespaceDependencies = (url, namespace, apikey) => {
     async function getNamespaceDependencies(...queryParameters) {
         try {
             // fetch namespace list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/dependencies${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/dependencies${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {

--- a/src/namespaces/index.js
+++ b/src/namespaces/index.js
@@ -90,7 +90,7 @@ export const useDirektivNamespaces = (url, stream, apikey) => {
     async function getNamespaces(...queryParameters) {
         try {
             // fetch namespace list by default
-            let resp = await fetch(`${url}namespaces${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -107,7 +107,7 @@ export const useDirektivNamespaces = (url, stream, apikey) => {
     // createNamespace creates a namespace from direktiv
     async function createNamespace(namespace, ...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "PUT",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
@@ -122,7 +122,7 @@ export const useDirektivNamespaces = (url, stream, apikey) => {
     // deleteNamespace deletes a namespace from direktiv
     async function deleteNamespace(namespace, ...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}?recursive=true${ExtractQueryString(true, queryParameters)}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}?recursive=true${ExtractQueryString(true, ...queryParameters)}`,{
                 method:"DELETE",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })

--- a/src/namespaces/index.js
+++ b/src/namespaces/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { CloseEventSource, HandleError } from '../util'
+import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 const fetch = require('isomorphic-fetch')
 
@@ -87,10 +87,10 @@ export const useDirektivNamespaces = (url, stream, apikey) => {
     },[eventSource])
 
     // getNamespaces returns a list of namespaces
-    async function getNamespaces() {
+    async function getNamespaces(...queryParameters) {
         try {
             // fetch namespace list by default
-            let resp = await fetch(`${url}namespaces`, {
+            let resp = await fetch(`${url}namespaces${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {

--- a/src/namespaces/index.js
+++ b/src/namespaces/index.js
@@ -105,9 +105,9 @@ export const useDirektivNamespaces = (url, stream, apikey) => {
     }
 
     // createNamespace creates a namespace from direktiv
-    async function createNamespace(namespace) {
+    async function createNamespace(namespace, ...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}${ExtractQueryString(false, queryParameters)}`, {
                 method: "PUT",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
@@ -120,9 +120,9 @@ export const useDirektivNamespaces = (url, stream, apikey) => {
     }
 
     // deleteNamespace deletes a namespace from direktiv
-    async function deleteNamespace(namespace) {
+    async function deleteNamespace(namespace, ...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}?recursive=true`,{
+            let resp = await fetch(`${url}namespaces/${namespace}?recursive=true${ExtractQueryString(true, queryParameters)}`,{
                 method:"DELETE",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })

--- a/src/namespaces/logs.js
+++ b/src/namespaces/logs.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import fetch from "cross-fetch"
-import { CloseEventSource, HandleError } from '../util'
+import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 
 /*

--- a/src/namespaces/logs.js
+++ b/src/namespaces/logs.js
@@ -59,7 +59,7 @@ export const useDirektivNamespaceLogs = (url, stream, namespace, apikey) => {
     async function getNamespaceLogs(...queryParameters) {
         try {
             // fetch namespace list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/logs${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/logs${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {

--- a/src/namespaces/logs.js
+++ b/src/namespaces/logs.js
@@ -56,10 +56,10 @@ export const useDirektivNamespaceLogs = (url, stream, namespace, apikey) => {
     },[eventSource])
 
     // getNamespaces returns a list of namespaces
-    async function getNamespaceLogs() {
+    async function getNamespaceLogs(...queryParameters) {
         try {
             // fetch namespace list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/logs`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/logs${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {

--- a/src/namespaces/metrics.js
+++ b/src/namespaces/metrics.js
@@ -12,9 +12,9 @@ import { HandleError, ExtractQueryString } from '../util'
 export const useDirektivNamespaceMetrics = (url, namespace, apikey) => {
     const [err, setErr] = React.useState(null)
 
-    async function getInvoked(){
+    async function getInvoked(...queryParameters){
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/metrics/invoked`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/metrics/invoked${ExtractQueryString(false, queryParameters)}`,{
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if(resp.ok){
@@ -27,9 +27,9 @@ export const useDirektivNamespaceMetrics = (url, namespace, apikey) => {
         }
     }
 
-    async function getSuccessful(){
+    async function getSuccessful(...queryParameters){
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/metrics/successful`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/metrics/successful${ExtractQueryString(false, queryParameters)}`,{
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if(resp.ok){
@@ -42,9 +42,9 @@ export const useDirektivNamespaceMetrics = (url, namespace, apikey) => {
         }
     }
 
-    async function getFailed() {
+    async function getFailed(...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/metrics/failed`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/metrics/failed${ExtractQueryString(false, queryParameters)}`,{
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if(resp.ok){
@@ -57,9 +57,9 @@ export const useDirektivNamespaceMetrics = (url, namespace, apikey) => {
         }
     }
 
-    async function getMilliseconds() {
+    async function getMilliseconds(...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/metrics/milliseconds`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/metrics/milliseconds${ExtractQueryString(false, queryParameters)}`,{
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if(resp.ok){

--- a/src/namespaces/metrics.js
+++ b/src/namespaces/metrics.js
@@ -14,7 +14,7 @@ export const useDirektivNamespaceMetrics = (url, namespace, apikey) => {
 
     async function getInvoked(...queryParameters){
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/metrics/invoked${ExtractQueryString(false, queryParameters)}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/metrics/invoked${ExtractQueryString(false, ...queryParameters)}`,{
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if(resp.ok){
@@ -29,7 +29,7 @@ export const useDirektivNamespaceMetrics = (url, namespace, apikey) => {
 
     async function getSuccessful(...queryParameters){
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/metrics/successful${ExtractQueryString(false, queryParameters)}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/metrics/successful${ExtractQueryString(false, ...queryParameters)}`,{
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if(resp.ok){
@@ -44,7 +44,7 @@ export const useDirektivNamespaceMetrics = (url, namespace, apikey) => {
 
     async function getFailed(...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/metrics/failed${ExtractQueryString(false, queryParameters)}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/metrics/failed${ExtractQueryString(false, ...queryParameters)}`,{
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if(resp.ok){
@@ -59,7 +59,7 @@ export const useDirektivNamespaceMetrics = (url, namespace, apikey) => {
 
     async function getMilliseconds(...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/metrics/milliseconds${ExtractQueryString(false, queryParameters)}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/metrics/milliseconds${ExtractQueryString(false, ...queryParameters)}`,{
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if(resp.ok){

--- a/src/namespaces/metrics.js
+++ b/src/namespaces/metrics.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import fetch from "cross-fetch"
-import { HandleError } from '../util'
+import { HandleError, ExtractQueryString } from '../util'
 
 /*
     useNamespaceMetrics is a react hook which metric details

--- a/src/namespaces/variables.js
+++ b/src/namespaces/variables.js
@@ -56,10 +56,10 @@ export const useDirektivNamespaceVariables = (url, stream, namespace, apikey) =>
     },[eventSource])
 
     // getNamespaces returns a list of namespaces
-    async function getNamespaceVariables() {
+    async function getNamespaceVariables(...queryParameters) {
         try {
             // fetch namespace list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/vars`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/vars${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -73,9 +73,9 @@ export const useDirektivNamespaceVariables = (url, stream, namespace, apikey) =>
         }
     }
 
-    async function getNamespaceVariable(name) {
+    async function getNamespaceVariable(name, ...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}`, {})
+            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, queryParameters)}`, {})
             if(resp.ok) {
                 return {data: await resp.text(), contentType: resp.headers.get("Content-Type")}
             } else {
@@ -86,9 +86,9 @@ export const useDirektivNamespaceVariables = (url, stream, namespace, apikey) =>
         }
     }
 
-    async function deleteNamespaceVariable(name) {
+    async function deleteNamespaceVariable(name,...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, queryParameters)}`,{
                 method: "DELETE"
             })
             if(!resp.ok) {
@@ -99,12 +99,12 @@ export const useDirektivNamespaceVariables = (url, stream, namespace, apikey) =>
         }
     }
 
-    async function setNamespaceVariable(name, val, mimeType) {
+    async function setNamespaceVariable(name, val, mimeType,...queryParameters) {
         if(mimeType === undefined){
             mimeType = "application/json"
         }
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, queryParameters)}`, {
                 method: "PUT",
                 body: val,
                 headers: {

--- a/src/namespaces/variables.js
+++ b/src/namespaces/variables.js
@@ -59,7 +59,7 @@ export const useDirektivNamespaceVariables = (url, stream, namespace, apikey) =>
     async function getNamespaceVariables(...queryParameters) {
         try {
             // fetch namespace list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/vars${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/vars${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -75,7 +75,7 @@ export const useDirektivNamespaceVariables = (url, stream, namespace, apikey) =>
 
     async function getNamespaceVariable(name, ...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, queryParameters)}`, {})
+            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, ...queryParameters)}`, {})
             if(resp.ok) {
                 return {data: await resp.text(), contentType: resp.headers.get("Content-Type")}
             } else {
@@ -88,7 +88,7 @@ export const useDirektivNamespaceVariables = (url, stream, namespace, apikey) =>
 
     async function deleteNamespaceVariable(name,...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, queryParameters)}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, ...queryParameters)}`,{
                 method: "DELETE"
             })
             if(!resp.ok) {
@@ -104,7 +104,7 @@ export const useDirektivNamespaceVariables = (url, stream, namespace, apikey) =>
             mimeType = "application/json"
         }
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "PUT",
                 body: val,
                 headers: {

--- a/src/namespaces/variables.js
+++ b/src/namespaces/variables.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { CloseEventSource, HandleError } from '../util'
+import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 const fetch = require('isomorphic-fetch')
 

--- a/src/nodes/index.js
+++ b/src/nodes/index.js
@@ -398,7 +398,7 @@ export const useDirektivNodes = (url, stream, namespace, path, apikey, orderFiel
             if(path !== "") {
                 uri += `${sanitizePath(path)}`
             }
-            let resp = await fetch(`${uri}/${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${uri}/${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -428,7 +428,7 @@ export const useDirektivNodes = (url, stream, namespace, path, apikey, orderFiel
                 name += `?op=create-directory`
                 body = JSON.stringify(body)
             }
-            let resp = await fetch(`${uriPath}/${name}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${uriPath}/${name}${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "PUT",
                 body: body,
                 headers: apikey === undefined ? {}:{"apikey": apikey}
@@ -447,7 +447,7 @@ export const useDirektivNodes = (url, stream, namespace, path, apikey, orderFiel
             if(path){
                 uriPath += `${sanitizePath(path)}`
             }
-            let resp = await fetch(`${uriPath}/${name}?op=delete-node${ExtractQueryString(true, queryParameters)}`, {
+            let resp = await fetch(`${uriPath}/${name}?op=delete-node${ExtractQueryString(true, ...queryParameters)}`, {
                 method: "DELETE",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
@@ -465,7 +465,7 @@ export const useDirektivNodes = (url, stream, namespace, path, apikey, orderFiel
             if(path) {
                 uriPath += `${sanitizePath(fpath)}`
             }
-            let resp = await fetch(`${uriPath}/${oldname}?op=rename-node${ExtractQueryString(true, queryParameters)}`,{
+            let resp = await fetch(`${uriPath}/${oldname}?op=rename-node${ExtractQueryString(true, ...queryParameters)}`,{
                 method: "POST",
                 body: JSON.stringify({new: newname}),
                 headers: apikey === undefined ? {}:{"apikey": apikey}
@@ -480,7 +480,7 @@ export const useDirektivNodes = (url, stream, namespace, path, apikey, orderFiel
 
     async function getWorkflowRouter(workflow,...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/tree/${workflow}?op=router${ExtractQueryString(true, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/tree/${workflow}?op=router${ExtractQueryString(true, ...queryParameters)}`, {
                 method: "get",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
@@ -497,7 +497,7 @@ export const useDirektivNodes = (url, stream, namespace, path, apikey, orderFiel
 
     async function toggleWorkflow(workflow, active,...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/tree/${workflow}?op=toggle${ExtractQueryString(true, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/tree/${workflow}?op=toggle${ExtractQueryString(true, ...queryParameters)}`, {
                 method: "POST",
                 body: JSON.stringify({
                     live: active

--- a/src/nodes/index.js
+++ b/src/nodes/index.js
@@ -392,13 +392,13 @@ export const useDirektivNodes = (url, stream, namespace, path, apikey, orderFiel
         return () => CloseEventSource(eventSource)
     },[eventSource])
 
-    async function getNode() {
+    async function getNode(...queryParameters) {
         try {
             let uri = `${url}namespaces/${namespace}/tree`
             if(path !== "") {
                 uri += `${sanitizePath(path)}`
             }
-            let resp = await fetch(`${uri}/`, {
+            let resp = await fetch(`${uri}/${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -412,7 +412,7 @@ export const useDirektivNodes = (url, stream, namespace, path, apikey, orderFiel
         }
     }
 
-    async function createNode(name, type, yaml) {
+    async function createNode(name, type, yaml,...queryParameters) {
         try {
             let uriPath = `${url}namespaces/${namespace}/tree`
             if(path !== "") {
@@ -428,7 +428,7 @@ export const useDirektivNodes = (url, stream, namespace, path, apikey, orderFiel
                 name += `?op=create-directory`
                 body = JSON.stringify(body)
             }
-            let resp = await fetch(`${uriPath}/${name}`, {
+            let resp = await fetch(`${uriPath}/${name}${ExtractQueryString(false, queryParameters)}`, {
                 method: "PUT",
                 body: body,
                 headers: apikey === undefined ? {}:{"apikey": apikey}
@@ -441,13 +441,13 @@ export const useDirektivNodes = (url, stream, namespace, path, apikey, orderFiel
         }
     }
 
-    async function deleteNode(name) {
+    async function deleteNode(name,...queryParameters) {
         try {
             let uriPath = `${url}namespaces/${namespace}/tree`
             if(path){
                 uriPath += `${sanitizePath(path)}`
             }
-            let resp = await fetch(`${uriPath}/${name}?op=delete-node`, {
+            let resp = await fetch(`${uriPath}/${name}?op=delete-node${ExtractQueryString(true, queryParameters)}`, {
                 method: "DELETE",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
@@ -459,13 +459,13 @@ export const useDirektivNodes = (url, stream, namespace, path, apikey, orderFiel
         }
     }
 
-    async function renameNode(fpath, oldname, newname) {
+    async function renameNode(fpath, oldname, newname,...queryParameters) {
         try {
             let uriPath = `${url}namespaces/${namespace}/tree`
             if(path) {
                 uriPath += `${sanitizePath(fpath)}`
             }
-            let resp = await fetch(`${uriPath}/${oldname}?op=rename-node`,{
+            let resp = await fetch(`${uriPath}/${oldname}?op=rename-node${ExtractQueryString(true, queryParameters)}`,{
                 method: "POST",
                 body: JSON.stringify({new: newname}),
                 headers: apikey === undefined ? {}:{"apikey": apikey}
@@ -478,9 +478,9 @@ export const useDirektivNodes = (url, stream, namespace, path, apikey, orderFiel
         }
     }
 
-    async function getWorkflowRouter(workflow) {
+    async function getWorkflowRouter(workflow,...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/tree/${workflow}?op=router`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/tree/${workflow}?op=router${ExtractQueryString(true, queryParameters)}`, {
                 method: "get",
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
@@ -495,9 +495,9 @@ export const useDirektivNodes = (url, stream, namespace, path, apikey, orderFiel
         }
     }
 
-    async function toggleWorkflow(workflow, active) {
+    async function toggleWorkflow(workflow, active,...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/tree/${workflow}?op=toggle`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/tree/${workflow}?op=toggle${ExtractQueryString(true, queryParameters)}`, {
                 method: "POST",
                 body: JSON.stringify({
                     live: active

--- a/src/nodes/index.js
+++ b/src/nodes/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { CloseEventSource, HandleError } from '../util'
+import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 const fetch = require('isomorphic-fetch')
 

--- a/src/registries/global-private.js
+++ b/src/registries/global-private.js
@@ -20,9 +20,9 @@ export const useDirektivGlobalPrivateRegistries = (url, apikey) => {
     },[data])
 
     // getGlobalPrivateRegistries returns a list of registries
-    async function getRegistries() {
+    async function getRegistries(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/registries/private`, {
+            let resp = await fetch(`${url}functions/registries/private${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -36,9 +36,9 @@ export const useDirektivGlobalPrivateRegistries = (url, apikey) => {
         }
     }
 
-    async function createRegistry(key, val){
+    async function createRegistry(key, val,...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/registries/private`, {
+            let resp = await fetch(`${url}functions/registries/private${ExtractQueryString(false, queryParameters)}`, {
                 method: "POST",
                 body: JSON.stringify({data:val, reg: key})
             })
@@ -51,9 +51,9 @@ export const useDirektivGlobalPrivateRegistries = (url, apikey) => {
         }
     }
 
-    async function deleteRegistry(key){
+    async function deleteRegistry(key,...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/registries/private`, {
+            let resp = await fetch(`${url}functions/registries/private${ExtractQueryString(false, queryParameters)}`, {
                 method: "DELETE",
                 body: JSON.stringify({
                     reg: key

--- a/src/registries/global-private.js
+++ b/src/registries/global-private.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {  HandleError } from '../util'
+import {  HandleError, ExtractQueryString } from '../util'
 const fetch = require('isomorphic-fetch')
 
 /*

--- a/src/registries/global-private.js
+++ b/src/registries/global-private.js
@@ -22,7 +22,7 @@ export const useDirektivGlobalPrivateRegistries = (url, apikey) => {
     // getGlobalPrivateRegistries returns a list of registries
     async function getRegistries(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/registries/private${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/registries/private${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -38,7 +38,7 @@ export const useDirektivGlobalPrivateRegistries = (url, apikey) => {
 
     async function createRegistry(key, val,...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/registries/private${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/registries/private${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "POST",
                 body: JSON.stringify({data:val, reg: key})
             })
@@ -53,7 +53,7 @@ export const useDirektivGlobalPrivateRegistries = (url, apikey) => {
 
     async function deleteRegistry(key,...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/registries/private${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/registries/private${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "DELETE",
                 body: JSON.stringify({
                     reg: key

--- a/src/registries/global.js
+++ b/src/registries/global.js
@@ -22,7 +22,7 @@ export const useDirektivGlobalRegistries = (url, apikey) => {
     // getGlobalRegistries returns a list of registries
     async function getRegistries(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/registries/global${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/registries/global${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -38,7 +38,7 @@ export const useDirektivGlobalRegistries = (url, apikey) => {
 
     async function createRegistry(key, val,...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/registries/global${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/registries/global${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "POST",
                 body: JSON.stringify({data:val, reg: key})
             })
@@ -53,7 +53,7 @@ export const useDirektivGlobalRegistries = (url, apikey) => {
 
     async function deleteRegistry(key, ...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/registries/global${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/registries/global${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "DELETE",
                 body: JSON.stringify({
                     reg: key

--- a/src/registries/global.js
+++ b/src/registries/global.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {  HandleError } from '../util'
+import {  HandleError, ExtractQueryString } from '../util'
 const fetch = require('isomorphic-fetch')
 
 /*

--- a/src/registries/global.js
+++ b/src/registries/global.js
@@ -20,9 +20,9 @@ export const useDirektivGlobalRegistries = (url, apikey) => {
     },[data])
 
     // getGlobalRegistries returns a list of registries
-    async function getRegistries() {
+    async function getRegistries(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/registries/global`, {
+            let resp = await fetch(`${url}functions/registries/global${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -36,9 +36,9 @@ export const useDirektivGlobalRegistries = (url, apikey) => {
         }
     }
 
-    async function createRegistry(key, val){
+    async function createRegistry(key, val,...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/registries/global`, {
+            let resp = await fetch(`${url}functions/registries/global${ExtractQueryString(false, queryParameters)}`, {
                 method: "POST",
                 body: JSON.stringify({data:val, reg: key})
             })
@@ -51,9 +51,9 @@ export const useDirektivGlobalRegistries = (url, apikey) => {
         }
     }
 
-    async function deleteRegistry(key){
+    async function deleteRegistry(key, ...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/registries/global`, {
+            let resp = await fetch(`${url}functions/registries/global${ExtractQueryString(false, queryParameters)}`, {
                 method: "DELETE",
                 body: JSON.stringify({
                     reg: key

--- a/src/registries/index.js
+++ b/src/registries/index.js
@@ -26,7 +26,7 @@ export const useDirektivRegistries = (url, namespace, apikey) => {
     // getRegistries returns a list of registries
     async function getRegistries(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/registries/namespaces/${namespace}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/registries/namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -42,7 +42,7 @@ export const useDirektivRegistries = (url, namespace, apikey) => {
 
     async function createRegistry(key, val,...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/registries/namespaces/${namespace}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/registries/namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "POST",
                 body: JSON.stringify({data:val, reg: key})
             })
@@ -56,7 +56,7 @@ export const useDirektivRegistries = (url, namespace, apikey) => {
 
     async function deleteRegistry(key,...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/registries/namespaces/${namespace}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/registries/namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "DELETE",
                 body: JSON.stringify({
                     reg: key

--- a/src/registries/index.js
+++ b/src/registries/index.js
@@ -24,9 +24,9 @@ export const useDirektivRegistries = (url, namespace, apikey) => {
     },[data])
 
     // getRegistries returns a list of registries
-    async function getRegistries() {
+    async function getRegistries(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/registries/namespaces/${namespace}`, {
+            let resp = await fetch(`${url}functions/registries/namespaces/${namespace}${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -40,9 +40,9 @@ export const useDirektivRegistries = (url, namespace, apikey) => {
         }
     }
 
-    async function createRegistry(key, val){
+    async function createRegistry(key, val,...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/registries/namespaces/${namespace}`, {
+            let resp = await fetch(`${url}functions/registries/namespaces/${namespace}${ExtractQueryString(false, queryParameters)}`, {
                 method: "POST",
                 body: JSON.stringify({data:val, reg: key})
             })
@@ -54,9 +54,9 @@ export const useDirektivRegistries = (url, namespace, apikey) => {
         }
     }
 
-    async function deleteRegistry(key){
+    async function deleteRegistry(key,...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/registries/namespaces/${namespace}`, {
+            let resp = await fetch(`${url}functions/registries/namespaces/${namespace}${ExtractQueryString(false, queryParameters)}`, {
                 method: "DELETE",
                 body: JSON.stringify({
                     reg: key

--- a/src/registries/index.js
+++ b/src/registries/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {  HandleError } from '../util'
+import {  HandleError, ExtractQueryString } from '../util'
 const fetch = require("isomorphic-fetch")
 
 /*

--- a/src/secrets/index.js
+++ b/src/secrets/index.js
@@ -20,9 +20,9 @@ export const useDirektivSecrets = (url, namespace, apikey) => {
     },[data])
 
     // getSecrets returns a list of registries
-    async function getSecrets() {
+    async function getSecrets(...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/secrets`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/secrets${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -36,9 +36,9 @@ export const useDirektivSecrets = (url, namespace, apikey) => {
         }
     }
 
-    async function createSecret(name,value) {
+    async function createSecret(name,value,...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/secrets/${name}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/secrets/${name}${ExtractQueryString(false, queryParameters)}`,{
                 method: "PUT",
                 body: value
             })
@@ -50,9 +50,9 @@ export const useDirektivSecrets = (url, namespace, apikey) => {
         }
     }
 
-    async function deleteSecret(name) {
+    async function deleteSecret(name,...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/secrets/${name}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/secrets/${name}${ExtractQueryString(false, queryParameters)}`, {
                 method: "DELETE"
             })
             if (!resp.ok) {

--- a/src/secrets/index.js
+++ b/src/secrets/index.js
@@ -22,7 +22,7 @@ export const useDirektivSecrets = (url, namespace, apikey) => {
     // getSecrets returns a list of registries
     async function getSecrets(...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/secrets${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/secrets${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -38,7 +38,7 @@ export const useDirektivSecrets = (url, namespace, apikey) => {
 
     async function createSecret(name,value,...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/secrets/${name}${ExtractQueryString(false, queryParameters)}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/secrets/${name}${ExtractQueryString(false, ...queryParameters)}`,{
                 method: "PUT",
                 body: value
             })
@@ -52,7 +52,7 @@ export const useDirektivSecrets = (url, namespace, apikey) => {
 
     async function deleteSecret(name,...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/secrets/${name}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/secrets/${name}${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "DELETE"
             })
             if (!resp.ok) {

--- a/src/secrets/index.js
+++ b/src/secrets/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {  HandleError } from '../util'
+import {  HandleError, ExtractQueryString } from '../util'
 const fetch = require('isomorphic-fetch')
 
 /*

--- a/src/services/global.js
+++ b/src/services/global.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { CloseEventSource, HandleError } from '../util'
+import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 const fetch = require('isomorphic-fetch')
 

--- a/src/services/global.js
+++ b/src/services/global.js
@@ -249,7 +249,7 @@ export const useDirektivGlobalService = (url, service, apikey) => {
 
     async function createGlobalServiceRevision(image, minScale, size, cmd, traffic,...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/${service}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/${service}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "POST",
                 body: JSON.stringify({
@@ -270,7 +270,7 @@ export const useDirektivGlobalService = (url, service, apikey) => {
 
     async function deleteGlobalServiceRevision(rev,...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/${service}/revisions/${rev}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/${service}/revisions/${rev}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "DELETE"
             })
@@ -284,7 +284,7 @@ export const useDirektivGlobalService = (url, service, apikey) => {
 
     async function getServiceConfig(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/${service}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/${service}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
             })
@@ -301,7 +301,7 @@ export const useDirektivGlobalService = (url, service, apikey) => {
 
     async function setGlobalServiceRevisionTraffic(rev1, rev1value, rev2, rev2value,...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/${service}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/${service}${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "PATCH",
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 body: JSON.stringify({values:[{
@@ -424,7 +424,7 @@ export const useDirektivGlobalServices = (url, stream, apikey) => {
 
     async function getConfig(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
             })
@@ -441,7 +441,7 @@ export const useDirektivGlobalServices = (url, stream, apikey) => {
 
     async function getGlobalServices(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
             })
@@ -458,7 +458,7 @@ export const useDirektivGlobalServices = (url, stream, apikey) => {
 
     async function createGlobalService(name, image, minScale, size, cmd,...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "POST",
                 body: JSON.stringify({
@@ -479,7 +479,7 @@ export const useDirektivGlobalServices = (url, stream, apikey) => {
 
     async function deleteGlobalService(name,...queryParameters) {
         try {
-            let resp = await fetch(`${url}/functions/${name}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}/functions/${name}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "DELETE"
             })

--- a/src/services/global.js
+++ b/src/services/global.js
@@ -247,9 +247,9 @@ export const useDirektivGlobalService = (url, service, apikey) => {
         }
     },[eventSource, trafficSource])
 
-    async function createGlobalServiceRevision(image, minScale, size, cmd, traffic) {
+    async function createGlobalServiceRevision(image, minScale, size, cmd, traffic,...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/${service}`, {
+            let resp = await fetch(`${url}functions/${service}${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "POST",
                 body: JSON.stringify({
@@ -268,9 +268,9 @@ export const useDirektivGlobalService = (url, service, apikey) => {
         }
     }
 
-    async function deleteGlobalServiceRevision(rev){
+    async function deleteGlobalServiceRevision(rev,...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/${service}/revisions/${rev}`, {
+            let resp = await fetch(`${url}functions/${service}/revisions/${rev}${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "DELETE"
             })
@@ -282,9 +282,9 @@ export const useDirektivGlobalService = (url, service, apikey) => {
         }
     }
 
-    async function getServiceConfig() {
+    async function getServiceConfig(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/${service}`, {
+            let resp = await fetch(`${url}functions/${service}${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
             })
@@ -299,9 +299,9 @@ export const useDirektivGlobalService = (url, service, apikey) => {
         }
     }
 
-    async function setGlobalServiceRevisionTraffic(rev1, rev1value, rev2, rev2value) {
+    async function setGlobalServiceRevisionTraffic(rev1, rev1value, rev2, rev2value,...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/${service}`, {
+            let resp = await fetch(`${url}functions/${service}${ExtractQueryString(false, queryParameters)}`, {
                 method: "PATCH",
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 body: JSON.stringify({values:[{
@@ -422,9 +422,9 @@ export const useDirektivGlobalServices = (url, stream, apikey) => {
     },[eventSource])
 
 
-    async function getConfig() {
+    async function getConfig(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions`, {
+            let resp = await fetch(`${url}functions${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
             })
@@ -439,9 +439,9 @@ export const useDirektivGlobalServices = (url, stream, apikey) => {
         }
     }
 
-    async function getGlobalServices() {
+    async function getGlobalServices(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions`, {
+            let resp = await fetch(`${url}functions${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
             })
@@ -456,9 +456,9 @@ export const useDirektivGlobalServices = (url, stream, apikey) => {
         }
     }
 
-    async function createGlobalService(name, image, minScale, size, cmd) {
+    async function createGlobalService(name, image, minScale, size, cmd,...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions`, {
+            let resp = await fetch(`${url}functions${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "POST",
                 body: JSON.stringify({
@@ -477,9 +477,9 @@ export const useDirektivGlobalServices = (url, stream, apikey) => {
         }
     }
 
-    async function deleteGlobalService(name) {
+    async function deleteGlobalService(name,...queryParameters) {
         try {
-            let resp = await fetch(`${url}/functions/${name}`, {
+            let resp = await fetch(`${url}/functions/${name}${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "DELETE"
             })

--- a/src/services/logs.js
+++ b/src/services/logs.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import fetch from "cross-fetch"
-import { CloseEventSource, HandleError } from '../util'
+import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 
 /*

--- a/src/services/namespace.js
+++ b/src/services/namespace.js
@@ -249,9 +249,9 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
         }
     },[eventSource, trafficSource])
 
-    async function getNamespaceServiceConfig() {
+    async function getNamespaceServiceConfig(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
             })
@@ -266,9 +266,9 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
         }
     }
 
-    async function createNamespaceServiceRevision(image, minScale, size, cmd, traffic) {
+    async function createNamespaceServiceRevision(image, minScale, size, cmd, traffic,...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "POST",
                 body: JSON.stringify({
@@ -287,9 +287,9 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
         }
     }
 
-    async function deleteNamespaceServiceRevision(rev){
+    async function deleteNamespaceServiceRevision(rev,...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}/revisions/${rev}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}/revisions/${rev}${ExtractQueryString(false, queryParameters)}`, {
                 method: "DELETE",
                 headers: apikey === undefined ? {}:{"apikey": apikey},
             })
@@ -301,7 +301,7 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
         }
     }
 
-    async function setNamespaceServiceRevisionTraffic(rev1, rev1value, rev2, rev2value) {
+    async function setNamespaceServiceRevisionTraffic(rev1, rev1value, rev2, rev2value,...queryParameters) {
         try {
             let trafficarr = []
             if(rev1 !== "") {
@@ -316,7 +316,7 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
                     percent: rev2value
                 })
             }
-            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}${ExtractQueryString(false, queryParameters)}`, {
                 method: "PATCH",
                 body: JSON.stringify({values:trafficarr})
             })
@@ -427,9 +427,9 @@ export const useDirektivNamespaceServices = (url, stream, namespace, apikey) => 
     },[eventSource])
 
 
-    async function getNamespaceServices() {
+    async function getNamespaceServices(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
             })
@@ -444,9 +444,9 @@ export const useDirektivNamespaceServices = (url, stream, namespace, apikey) => 
         }
     }
 
-    async function getNamespaceConfig() {
+    async function getNamespaceConfig(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
             })
@@ -461,9 +461,9 @@ export const useDirektivNamespaceServices = (url, stream, namespace, apikey) => 
         }
     }
 
-    async function createNamespaceService(name, image, minScale, size, cmd) {
+    async function createNamespaceService(name, image, minScale, size, cmd,...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "POST",
                 body: JSON.stringify({
@@ -482,9 +482,9 @@ export const useDirektivNamespaceServices = (url, stream, namespace, apikey) => 
         }
     }
 
-    async function deleteNamespaceService(name) {
+    async function deleteNamespaceService(name,...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${name}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${name}${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "DELETE"
             })

--- a/src/services/namespace.js
+++ b/src/services/namespace.js
@@ -251,7 +251,7 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
 
     async function getNamespaceServiceConfig(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
             })
@@ -268,7 +268,7 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
 
     async function createNamespaceServiceRevision(image, minScale, size, cmd, traffic,...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "POST",
                 body: JSON.stringify({
@@ -289,7 +289,7 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
 
     async function deleteNamespaceServiceRevision(rev,...queryParameters){
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}/revisions/${rev}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}/revisions/${rev}${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "DELETE",
                 headers: apikey === undefined ? {}:{"apikey": apikey},
             })
@@ -316,7 +316,7 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
                     percent: rev2value
                 })
             }
-            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "PATCH",
                 body: JSON.stringify({values:trafficarr})
             })
@@ -429,7 +429,7 @@ export const useDirektivNamespaceServices = (url, stream, namespace, apikey) => 
 
     async function getNamespaceServices(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
             })
@@ -446,7 +446,7 @@ export const useDirektivNamespaceServices = (url, stream, namespace, apikey) => 
 
     async function getNamespaceConfig(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
             })
@@ -463,7 +463,7 @@ export const useDirektivNamespaceServices = (url, stream, namespace, apikey) => 
 
     async function createNamespaceService(name, image, minScale, size, cmd,...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "POST",
                 body: JSON.stringify({
@@ -484,7 +484,7 @@ export const useDirektivNamespaceServices = (url, stream, namespace, apikey) => 
 
     async function deleteNamespaceService(name,...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${name}${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${name}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "DELETE"
             })

--- a/src/services/namespace.js
+++ b/src/services/namespace.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { CloseEventSource, HandleError } from '../util'
+import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const fetch = require("isomorphic-fetch")
 const {EventSourcePolyfill} = require('event-source-polyfill')
 

--- a/src/services/workflow.js
+++ b/src/services/workflow.js
@@ -309,9 +309,9 @@ export const useDirektivWorkflowServices = (url, stream, namespace, path, apikey
     },[eventSource])
 
 
-    async function getWorkflowServices() {
+    async function getWorkflowServices(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}/tree/${path}?op=services`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}/tree/${path}?op=services${ExtractQueryString(true, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
             })

--- a/src/services/workflow.js
+++ b/src/services/workflow.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { CloseEventSource, HandleError } from '../util'
+import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 const fetch = require('isomorphic-fetch')
 /* 

--- a/src/services/workflow.js
+++ b/src/services/workflow.js
@@ -311,7 +311,7 @@ export const useDirektivWorkflowServices = (url, stream, namespace, path, apikey
 
     async function getWorkflowServices(...queryParameters) {
         try {
-            let resp = await fetch(`${url}functions/namespaces/${namespace}/tree/${path}?op=services${ExtractQueryString(true, queryParameters)}`, {
+            let resp = await fetch(`${url}functions/namespaces/${namespace}/tree/${path}?op=services${ExtractQueryString(true, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
             })

--- a/src/util.js
+++ b/src/util.js
@@ -39,3 +39,21 @@ export async function HandleError(summary, resp, perm) {
         return `You do not have permission to '${summary}', contact system admin to grant '${perm}'`
     }
 }
+
+export function ExtractQueryString(appendMode, ...queryParameters) {
+    let queryString = ""
+    for (let i = 0; i < queryParameters.length; i++) {
+        const query = queryParameters[i];
+        if (i > 0 || appendMode) {
+            queryString += `&${query}`
+        } else {
+            queryString += query
+        }
+    }
+
+    if (appendMode) {
+        return queryString
+    }
+
+    return `?${queryString}`
+}

--- a/src/util.js
+++ b/src/util.js
@@ -45,7 +45,7 @@ export function ExtractQueryString(appendMode, ...queryParameters) {
     for (let i = 0; i < queryParameters.length; i++) {
         const query = queryParameters[i];
         if (i > 0 || appendMode) {
-            queryString += `&${query}`
+            queryString += "&" + query
         } else {
             queryString += query
         }

--- a/src/workflow/index.js
+++ b/src/workflow/index.js
@@ -55,11 +55,11 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
     },[eventSource])
 
 
-    async function getWorkflow() {
+    async function getWorkflow(...queryParameters) {
         try {
             let uri = `${url}namespaces/${namespace}/tree/${path}`
  
-            let resp = await fetch(`${uri}/`, {
+            let resp = await fetch(`${uri}/${ExtractQueryString(false, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -73,14 +73,14 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function getWorkflowSankeyMetrics(rev) {
+    async function getWorkflowSankeyMetrics(rev,...queryParameters) {
         let ref = "latest"
         if(rev){
             ref = rev
         }
 
         let uri = `${url}namespaces/${namespace}/tree/${path}?ref=${rev}&op=metrics-sankey`
-        let resp = await fetch(`${uri}`, {
+        let resp = await fetch(`${uri}${ExtractQueryString(true, queryParameters)}`, {
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
         if (resp.ok) {
@@ -90,9 +90,9 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function getWorkflowRevisionData(rev) {
+    async function getWorkflowRevisionData(rev,...queryParameters) {
         let uri = `${url}namespaces/${namespace}/tree/${path}?ref=${rev}`
-        let resp = await fetch(`${uri}`, {
+        let resp = await fetch(`${uri}${ExtractQueryString(true, queryParameters)}`, {
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
         if (resp.ok) {
@@ -102,8 +102,8 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function getRevisions(){
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=refs`,{
+    async function getRevisions(...queryParameters){
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=refs${ExtractQueryString(true, queryParameters)}`,{
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
         if(resp.ok) {
@@ -114,8 +114,8 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function getTags(){
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=tags`,{
+    async function getTags(...queryParameters){
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=tags${ExtractQueryString(true, queryParameters)}`,{
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
         if(resp.ok) {
@@ -126,8 +126,8 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function updateWorkflow(newwf) {
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=update-workflow`, {
+    async function updateWorkflow(newwf,...queryParameters) {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=update-workflow${ExtractQueryString(true, queryParameters)}`, {
             method: "post",
             headers: apikey === undefined ? {}:{"apikey": apikey},
             headers: {
@@ -142,8 +142,8 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function toggleWorkflow(active) {
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=toggle`, {
+    async function toggleWorkflow(active,...queryParameters) {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=toggle${ExtractQueryString(true, queryParameters)}`, {
             method: "POST",
             body: JSON.stringify({
                 live: active
@@ -155,8 +155,8 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function getWorkflowRouter() {
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=router`, {
+    async function getWorkflowRouter(...queryParameters) {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=router${ExtractQueryString(true, queryParameters)}`, {
             method: "get",
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
@@ -167,8 +167,8 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function editWorkflowRouter(routes, live) {
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=edit-router`, {
+    async function editWorkflowRouter(routes, live,...queryParameters) {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=edit-router${ExtractQueryString(true, queryParameters)}`, {
             method: "POST",
             body: JSON.stringify({
                 route: routes,
@@ -181,8 +181,8 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function setWorkflowLogToEvent(val) {
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=set-workflow-event-logging`,{
+    async function setWorkflowLogToEvent(val,...queryParameters) {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=set-workflow-event-logging${ExtractQueryString(true, queryParameters)}`,{
             method: "POST",
             body: JSON.stringify({
                 logger: val
@@ -194,12 +194,12 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function executeWorkflow(input, revision) {
+    async function executeWorkflow(input, revision,...queryParameters) {
         let ref = "latest"
         if(revision) {
             ref = revision
         }
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=execute&ref=${ref}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=execute&ref=${ref}${ExtractQueryString(true, queryParameters)}`, {
             method: "POST",
             body: input,
             headers: apikey === undefined ? {}:{"apikey": apikey}
@@ -212,8 +212,8 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function addAttributes(attributes) {
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=create-node-attributes`, {
+    async function addAttributes(attributes,...queryParameters) {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=create-node-attributes${ExtractQueryString(true, queryParameters)}`, {
             method: "PUT",
             body: JSON.stringify({
                 attributes: attributes
@@ -225,8 +225,8 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function deleteAttributes(attributes){
-                let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=delete-node-attributes`, {
+    async function deleteAttributes(attributes,...queryParameters){
+                let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=delete-node-attributes${ExtractQueryString(true, queryParameters)}`, {
             method: "DELETE",
             body: JSON.stringify({
                 attributes: attributes
@@ -238,8 +238,8 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function getInstancesForWorkflow() {
-        let resp = await fetch(`${url}namespaces/${namespace}/instances?filter.field=AS&filter.type=WORKFLOW&filter.val=${path}`,{
+    async function getInstancesForWorkflow(...queryParameters) {
+        let resp = await fetch(`${url}namespaces/${namespace}/instances?filter.field=AS&filter.type=WORKFLOW&filter.val=${path}${ExtractQueryString(true, queryParameters)}`,{
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
         if (resp.ok) {
@@ -250,11 +250,11 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function getSuccessFailedMetrics() {
-        let respFailed = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=metrics-failed`, {
+    async function getSuccessFailedMetrics(...queryParameters) {
+        let respFailed = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=metrics-failed${ExtractQueryString(true, queryParameters)}`, {
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
-        let respSuccess = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=metrics-successful`, {
+        let respSuccess = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=metrics-successful${ExtractQueryString(true, queryParameters)}`, {
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
 
@@ -280,8 +280,8 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         return x
     }
 
-    async function getStateMillisecondMetrics(){
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=metrics-state-milliseconds`, {
+    async function getStateMillisecondMetrics(...queryParameters){
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=metrics-state-milliseconds${ExtractQueryString(true, queryParameters)}`, {
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
         if (resp.ok) {
@@ -292,12 +292,12 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function saveWorkflow(ref){
+    async function saveWorkflow(ref,...queryParameters){
         let rev = ref
         if(rev === undefined){
             rev = "latest"
         }
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=save-workflow&ref=${rev}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=save-workflow&ref=${rev}${ExtractQueryString(true, queryParameters)}`, {
             method: "POST",
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
@@ -308,13 +308,13 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         return resp.json()
     }
 
-    async function deleteRevision(ref) {
+    async function deleteRevision(ref,...queryParameters) {
         let rev = ref
         if(rev === undefined){
             rev = "latest"
         }
 
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=delete-revision&ref=${ref}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=delete-revision&ref=${ref}${ExtractQueryString(true, queryParameters)}`, {
             method:"POST",
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
@@ -323,8 +323,8 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function removeTag(tag) {
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=untag&ref=${tag}`, {
+    async function removeTag(tag,...queryParameters) {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=untag&ref=${tag}${ExtractQueryString(true, queryParameters)}`, {
             method:"POST",
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
@@ -333,13 +333,13 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function discardWorkflow(ref) {
+    async function discardWorkflow(ref,...queryParameters) {
         let rev = ref
         if(rev === undefined){
             rev = "latest"
         }
 
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=discard-workflow&ref=${rev}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=discard-workflow&ref=${rev}${ExtractQueryString(true, queryParameters)}`, {
             method: "POST",
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
@@ -348,12 +348,12 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
     }
 
-    async function tagWorkflow(ref, tag) {
+    async function tagWorkflow(ref, tag,...queryParameters) {
         let rev = ref
         if(rev === undefined){
             rev = "latest"
         }
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=tag&ref=${ref}&tag=${tag}`,{
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=tag&ref=${ref}&tag=${tag}${ExtractQueryString(true, queryParameters)}`,{
             method: "POST",
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })

--- a/src/workflow/index.js
+++ b/src/workflow/index.js
@@ -59,7 +59,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         try {
             let uri = `${url}namespaces/${namespace}/tree/${path}`
  
-            let resp = await fetch(`${uri}/${ExtractQueryString(false, queryParameters)}`, {
+            let resp = await fetch(`${uri}/${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
@@ -80,7 +80,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         }
 
         let uri = `${url}namespaces/${namespace}/tree/${path}?ref=${rev}&op=metrics-sankey`
-        let resp = await fetch(`${uri}${ExtractQueryString(true, queryParameters)}`, {
+        let resp = await fetch(`${uri}${ExtractQueryString(true, ...queryParameters)}`, {
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
         if (resp.ok) {
@@ -92,7 +92,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
 
     async function getWorkflowRevisionData(rev,...queryParameters) {
         let uri = `${url}namespaces/${namespace}/tree/${path}?ref=${rev}`
-        let resp = await fetch(`${uri}${ExtractQueryString(true, queryParameters)}`, {
+        let resp = await fetch(`${uri}${ExtractQueryString(true, ...queryParameters)}`, {
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
         if (resp.ok) {
@@ -103,7 +103,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
     }
 
     async function getRevisions(...queryParameters){
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=refs${ExtractQueryString(true, queryParameters)}`,{
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=refs${ExtractQueryString(true, ...queryParameters)}`,{
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
         if(resp.ok) {
@@ -115,7 +115,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
     }
 
     async function getTags(...queryParameters){
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=tags${ExtractQueryString(true, queryParameters)}`,{
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=tags${ExtractQueryString(true, ...queryParameters)}`,{
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
         if(resp.ok) {
@@ -127,7 +127,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
     }
 
     async function updateWorkflow(newwf,...queryParameters) {
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=update-workflow${ExtractQueryString(true, queryParameters)}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=update-workflow${ExtractQueryString(true, ...queryParameters)}`, {
             method: "post",
             headers: apikey === undefined ? {}:{"apikey": apikey},
             headers: {
@@ -143,7 +143,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
     }
 
     async function toggleWorkflow(active,...queryParameters) {
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=toggle${ExtractQueryString(true, queryParameters)}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=toggle${ExtractQueryString(true, ...queryParameters)}`, {
             method: "POST",
             body: JSON.stringify({
                 live: active
@@ -156,7 +156,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
     }
 
     async function getWorkflowRouter(...queryParameters) {
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=router${ExtractQueryString(true, queryParameters)}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=router${ExtractQueryString(true, ...queryParameters)}`, {
             method: "get",
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
@@ -168,7 +168,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
     }
 
     async function editWorkflowRouter(routes, live,...queryParameters) {
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=edit-router${ExtractQueryString(true, queryParameters)}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=edit-router${ExtractQueryString(true, ...queryParameters)}`, {
             method: "POST",
             body: JSON.stringify({
                 route: routes,
@@ -182,7 +182,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
     }
 
     async function setWorkflowLogToEvent(val,...queryParameters) {
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=set-workflow-event-logging${ExtractQueryString(true, queryParameters)}`,{
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=set-workflow-event-logging${ExtractQueryString(true, ...queryParameters)}`,{
             method: "POST",
             body: JSON.stringify({
                 logger: val
@@ -199,7 +199,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         if(revision) {
             ref = revision
         }
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=execute&ref=${ref}${ExtractQueryString(true, queryParameters)}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=execute&ref=${ref}${ExtractQueryString(true, ...queryParameters)}`, {
             method: "POST",
             body: input,
             headers: apikey === undefined ? {}:{"apikey": apikey}
@@ -213,7 +213,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
     }
 
     async function addAttributes(attributes,...queryParameters) {
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=create-node-attributes${ExtractQueryString(true, queryParameters)}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=create-node-attributes${ExtractQueryString(true, ...queryParameters)}`, {
             method: "PUT",
             body: JSON.stringify({
                 attributes: attributes
@@ -226,7 +226,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
     }
 
     async function deleteAttributes(attributes,...queryParameters){
-                let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=delete-node-attributes${ExtractQueryString(true, queryParameters)}`, {
+                let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=delete-node-attributes${ExtractQueryString(true, ...queryParameters)}`, {
             method: "DELETE",
             body: JSON.stringify({
                 attributes: attributes
@@ -239,7 +239,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
     }
 
     async function getInstancesForWorkflow(...queryParameters) {
-        let resp = await fetch(`${url}namespaces/${namespace}/instances?filter.field=AS&filter.type=WORKFLOW&filter.val=${path}${ExtractQueryString(true, queryParameters)}`,{
+        let resp = await fetch(`${url}namespaces/${namespace}/instances?filter.field=AS&filter.type=WORKFLOW&filter.val=${path}${ExtractQueryString(true, ...queryParameters)}`,{
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
         if (resp.ok) {
@@ -251,10 +251,10 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
     }
 
     async function getSuccessFailedMetrics(...queryParameters) {
-        let respFailed = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=metrics-failed${ExtractQueryString(true, queryParameters)}`, {
+        let respFailed = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=metrics-failed${ExtractQueryString(true, ...queryParameters)}`, {
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
-        let respSuccess = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=metrics-successful${ExtractQueryString(true, queryParameters)}`, {
+        let respSuccess = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=metrics-successful${ExtractQueryString(true, ...queryParameters)}`, {
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
 
@@ -281,7 +281,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
     }
 
     async function getStateMillisecondMetrics(...queryParameters){
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=metrics-state-milliseconds${ExtractQueryString(true, queryParameters)}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=metrics-state-milliseconds${ExtractQueryString(true, ...queryParameters)}`, {
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
         if (resp.ok) {
@@ -297,7 +297,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         if(rev === undefined){
             rev = "latest"
         }
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=save-workflow&ref=${rev}${ExtractQueryString(true, queryParameters)}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=save-workflow&ref=${rev}${ExtractQueryString(true, ...queryParameters)}`, {
             method: "POST",
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
@@ -314,7 +314,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
             rev = "latest"
         }
 
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=delete-revision&ref=${ref}${ExtractQueryString(true, queryParameters)}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=delete-revision&ref=${ref}${ExtractQueryString(true, ...queryParameters)}`, {
             method:"POST",
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
@@ -324,7 +324,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
     }
 
     async function removeTag(tag,...queryParameters) {
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=untag&ref=${tag}${ExtractQueryString(true, queryParameters)}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=untag&ref=${tag}${ExtractQueryString(true, ...queryParameters)}`, {
             method:"POST",
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
@@ -339,7 +339,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
             rev = "latest"
         }
 
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=discard-workflow&ref=${rev}${ExtractQueryString(true, queryParameters)}`, {
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=discard-workflow&ref=${rev}${ExtractQueryString(true, ...queryParameters)}`, {
             method: "POST",
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })
@@ -353,7 +353,7 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
         if(rev === undefined){
             rev = "latest"
         }
-        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=tag&ref=${ref}&tag=${tag}${ExtractQueryString(true, queryParameters)}`,{
+        let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=tag&ref=${ref}&tag=${tag}${ExtractQueryString(true, ...queryParameters)}`,{
             method: "POST",
             headers: apikey === undefined ? {}:{"apikey": apikey}
         })

--- a/src/workflow/index.js
+++ b/src/workflow/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { CloseEventSource, HandleError } from '../util'
+import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 const fetch = require('isomorphic-fetch')
 

--- a/src/workflow/logs.js
+++ b/src/workflow/logs.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import fetch from "cross-fetch"
-import { CloseEventSource, HandleError } from '../util'
+import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 
 /*

--- a/src/workflow/logs.js
+++ b/src/workflow/logs.js
@@ -57,10 +57,10 @@ export const useDirektivWorkflowLogs = (url, stream, namespace, path, apikey) =>
     },[eventSource])
 
     // getWorkflowLogs returns a list of workflow logs
-    async function getWorkflowLogs() {
+    async function getWorkflowLogs(...queryParameters) {
         try {
             // fetch namespace list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=logs`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=logs${ExtractQueryString(true, queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {

--- a/src/workflow/logs.js
+++ b/src/workflow/logs.js
@@ -60,7 +60,7 @@ export const useDirektivWorkflowLogs = (url, stream, namespace, path, apikey) =>
     async function getWorkflowLogs(...queryParameters) {
         try {
             // fetch namespace list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=logs${ExtractQueryString(true, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=logs${ExtractQueryString(true, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {

--- a/src/workflow/variables.js
+++ b/src/workflow/variables.js
@@ -57,7 +57,7 @@ export const useDirektivWorkflowVariables = (url, stream, namespace, path, apike
 
     async function getWorkflowVariables(...queryParameters) {
         try {
-            let uri = `${url}namespaces/${namespace}/tree/${path}?op=vars${ExtractQueryString(true, queryParameters)}` 
+            let uri = `${url}namespaces/${namespace}/tree/${path}?op=vars${ExtractQueryString(true, ...queryParameters)}` 
             let resp = await fetch(`${uri}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
@@ -77,7 +77,7 @@ export const useDirektivWorkflowVariables = (url, stream, namespace, path, apike
             mimeType = "application/json"
         }
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=set-var&var=${name}${ExtractQueryString(true, queryParameters)}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=set-var&var=${name}${ExtractQueryString(true, ...queryParameters)}`, {
                 method: "PUT",
                 body: val,
                 headers: {
@@ -94,7 +94,7 @@ export const useDirektivWorkflowVariables = (url, stream, namespace, path, apike
 
     async function getWorkflowVariable(name,...queryParameters) {
         try {
-            let resp = await fetch(`${url}/namespaces/${namespace}/tree/${path}?op=var&var=${name}${ExtractQueryString(true, queryParameters)}`, {})
+            let resp = await fetch(`${url}/namespaces/${namespace}/tree/${path}?op=var&var=${name}${ExtractQueryString(true, ...queryParameters)}`, {})
             if(resp.ok) {
                 return {data: await resp.text(), contentType: resp.headers.get("Content-Type")}
             } else {
@@ -107,7 +107,7 @@ export const useDirektivWorkflowVariables = (url, stream, namespace, path, apike
 
     async function deleteWorkflowVariable(name,...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=delete-var&var=${name}${ExtractQueryString(true, queryParameters)}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=delete-var&var=${name}${ExtractQueryString(true, ...queryParameters)}`,{
                 method: "DELETE"
             })
             if(!resp.ok) {

--- a/src/workflow/variables.js
+++ b/src/workflow/variables.js
@@ -55,9 +55,9 @@ export const useDirektivWorkflowVariables = (url, stream, namespace, path, apike
     },[eventSource])
 
 
-    async function getWorkflowVariables() {
+    async function getWorkflowVariables(...queryParameters) {
         try {
-            let uri = `${url}namespaces/${namespace}/tree/${path}?op=vars` 
+            let uri = `${url}namespaces/${namespace}/tree/${path}?op=vars${ExtractQueryString(true, queryParameters)}` 
             let resp = await fetch(`${uri}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
@@ -72,12 +72,12 @@ export const useDirektivWorkflowVariables = (url, stream, namespace, path, apike
         }
     }
 
-    async function setWorkflowVariable(name, val, mimeType) {
+    async function setWorkflowVariable(name, val, mimeType,...queryParameters) {
         if(mimeType === undefined){
             mimeType = "application/json"
         }
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=set-var&var=${name}`, {
+            let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=set-var&var=${name}${ExtractQueryString(true, queryParameters)}`, {
                 method: "PUT",
                 body: val,
                 headers: {
@@ -92,9 +92,9 @@ export const useDirektivWorkflowVariables = (url, stream, namespace, path, apike
         }
     }
 
-    async function getWorkflowVariable(name) {
+    async function getWorkflowVariable(name,...queryParameters) {
         try {
-            let resp = await fetch(`${url}/namespaces/${namespace}/tree/${path}?op=var&var=${name}`, {})
+            let resp = await fetch(`${url}/namespaces/${namespace}/tree/${path}?op=var&var=${name}${ExtractQueryString(true, queryParameters)}`, {})
             if(resp.ok) {
                 return {data: await resp.text(), contentType: resp.headers.get("Content-Type")}
             } else {
@@ -105,9 +105,9 @@ export const useDirektivWorkflowVariables = (url, stream, namespace, path, apike
         }
     }
 
-    async function deleteWorkflowVariable(name) {
+    async function deleteWorkflowVariable(name,...queryParameters) {
         try {
-            let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=delete-var&var=${name}`,{
+            let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=delete-var&var=${name}${ExtractQueryString(true, queryParameters)}`,{
                 method: "DELETE"
             })
             if(!resp.ok) {

--- a/src/workflow/variables.js
+++ b/src/workflow/variables.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { CloseEventSource, HandleError } from '../util'
+import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 const fetch = require("isomorphic-fetch")
 


### PR DESCRIPTION
## Description

Added [Rest Parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) to all hook functions so that you can pass any query parameter you want

Like so (All examples are valid)
```js
# Fetches /api/functions/namespaces/jon
await getNamespaceConfig()

# Fetches /api/functions/namespaces/jon?extraQuery=VALUE
await getNamespaceConfig("extraQuery=VALUE")

# Multiple Queries also supported
# Fetches /api/functions/namespaces/jon?extraQuery=VALUE&anotherQuery=AnotherVALUE
await getNamespaceConfig("extraQuery=VALUE", "anotherQuery=AnotherVALUE")
```
## Purpose

- [ ] Bug fix
- [X] New feature
- [ ] Other


