### PR TITLE
Changed Error handling on hook functions to throw errors. Also added return bodies to some functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direktiv-react-hooks",
-  "version": "0.0.120",
+  "version": "0.0.128",
   "description": "A custom react hook library to talk to direktiv",
   "author": "direktiv",
   "license": "MIT",

--- a/src/event-configuration/index.js
+++ b/src/event-configuration/index.js
@@ -11,40 +11,32 @@ const fetch = require('isomorphic-fetch')
 */
 export const useDirektivBroadcastConfiguration = (url, namespace, apikey) => {
     const [data, setData] = React.useState(null)
-    const [err, setErr] = React.useState(null)
-
-    React.useEffect(()=>{
-        if(data === null) {
+    
+    React.useEffect(() => {
+        if (data === null) {
             getBroadcastConfiguration()
         }
-    },[data])
+    }, [data])
 
     async function getBroadcastConfiguration(...queryParameters) {
-        try {
-            let resp = await fetch(`${url}namespaces/${namespace}/config${ExtractQueryString(false, ...queryParameters)}`,{})
-            if(!resp.ok) {
-                await HandleError('fetch config', resp, 'getNamespaceConfiguration')
-            } else {
-                let json = await resp.json()
-                setData(json)
-            }
-        } catch(e) {
-            setErr(e.message)
+        let resp = await fetch(`${url}namespaces/${namespace}/config${ExtractQueryString(false, ...queryParameters)}`, {})
+        if (!resp.ok) {
+            throw new Error(await HandleError('fetch config', resp, 'getNamespaceConfiguration'))
         }
+        let json = await resp.json()
+        setData(json)
+        return json
     }
 
     async function setBroadcastConfiguration(newconfig, ...queryParameters) {
-        try {
-            let resp = await fetch(`${url}namespaces/${namespace}/config${ExtractQueryString(false, ...queryParameters)}`, {
-                method: "PATCH",
-                body: newconfig
-            })
-            if (!resp.ok) {
-                return await HandleError('set config', resp, 'setNamespaceConfiguration')
-            }
-        } catch (e) {
-            return e.message
+        let resp = await fetch(`${url}namespaces/${namespace}/config${ExtractQueryString(false, ...queryParameters)}`, {
+            method: "PATCH",
+            body: newconfig
+        })
+        if (!resp.ok) {
+            throw new Error(await HandleError('set config', resp, 'setNamespaceConfiguration'))
         }
+        return await resp.json()
     }
 
     return {

--- a/src/event-configuration/index.js
+++ b/src/event-configuration/index.js
@@ -11,7 +11,7 @@ const fetch = require('isomorphic-fetch')
 */
 export const useDirektivBroadcastConfiguration = (url, namespace, apikey) => {
     const [data, setData] = React.useState(null)
-    
+
     React.useEffect(() => {
         if (data === null) {
             getBroadcastConfiguration()
@@ -41,7 +41,6 @@ export const useDirektivBroadcastConfiguration = (url, namespace, apikey) => {
 
     return {
         data,
-        err,
         getBroadcastConfiguration,
         setBroadcastConfiguration
     }

--- a/src/instance/index.js
+++ b/src/instance/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
-const {EventSourcePolyfill} = require('event-source-polyfill')
+const { EventSourcePolyfill } = require('event-source-polyfill')
 const fetch = require('isomorphic-fetch')
 
 /*
@@ -19,27 +19,27 @@ export const useDirektivInstanceLogs = (url, stream, namespace, instance, apikey
     const [err, setErr] = React.useState(null)
     const [eventSource, setEventSource] = React.useState(null)
 
-    React.useEffect(()=>{
-        if(stream) {
+    React.useEffect(() => {
+        if (stream) {
             let log = logsRef.current
-            if (eventSource === null){
+            if (eventSource === null) {
                 // setup event listener 
                 let listener = new EventSourcePolyfill(`${url}namespaces/${namespace}/instances/${instance}/logs`, {
-                    headers: apikey === undefined ? {}:{"apikey": apikey}
+                    headers: apikey === undefined ? {} : { "apikey": apikey }
                 })
 
                 listener.onerror = (e) => {
-                    if(e.status === 403) {
+                    if (e.status === 403) {
                         setErr("permission denied")
                     }
                 }
 
                 async function readData(e) {
-                    if(e.data === "") {
+                    if (e.data === "") {
                         return
                     }
                     let json = JSON.parse(e.data)
-                    for(let i=0; i < json.edges.length; i++) {
+                    for (let i = 0; i < json.edges.length; i++) {
                         log.push(json.edges[i])
                     }
                     logsRef.current = log
@@ -50,32 +50,30 @@ export const useDirektivInstanceLogs = (url, stream, namespace, instance, apikey
                 setEventSource(listener)
             }
         } else {
-            if(data === null) {
+            if (data === null) {
                 getInstanceLogs()
             }
         }
-    },[data])
+    }, [data])
 
-    React.useEffect(()=>{
+    React.useEffect(() => {
         return () => CloseEventSource(eventSource)
-    },[eventSource])
+    }, [eventSource])
 
     // getInstanceLogs returns a list of logs
     async function getInstanceLogs(...queryParameters) {
-        try {
-            // fetch instance list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/logs${ExtractQueryString(false, ...queryParameters)}`, {
-                headers: apikey === undefined ? {}:{"apikey": apikey}
-            })
-            if (resp.ok){
-                let json = await resp.json()
-                setData(json.edges)
-            } else {
-                setErr(await HandleError('get instance logs', resp, "instanceLogs"))
-            }
-        } catch(e) {
-            setErr(e.message)
+        // fetch instance list by default
+        let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/logs${ExtractQueryString(false, ...queryParameters)}`, {
+            headers: apikey === undefined ? {} : { "apikey": apikey }
+        })
+        if (resp.ok) {
+            let json = await resp.json()
+            setData(json.edges)
+            return json.edges
         }
+
+        throw new Error(await HandleError('get instance logs', resp, "instanceLogs"))
+
     }
 
     return {
@@ -98,22 +96,22 @@ export const useDirektivInstance = (url, stream, namespace, instance, apikey) =>
     const [err, setErr] = React.useState(null)
     const [eventSource, setEventSource] = React.useState(null)
 
-    React.useEffect(()=>{
-        if(stream) {
-            if (eventSource === null){
+    React.useEffect(() => {
+        if (stream) {
+            if (eventSource === null) {
                 // setup event listener 
                 let listener = new EventSourcePolyfill(`${url}namespaces/${namespace}/instances/${instance}`, {
-                    headers: apikey === undefined ? {}:{"apikey": apikey}
+                    headers: apikey === undefined ? {} : { "apikey": apikey }
                 })
 
                 listener.onerror = (e) => {
-                    if(e.status === 403) {
+                    if (e.status === 403) {
                         setErr("permission denied")
                     }
                 }
 
                 async function readData(e) {
-                    if(e.data === "") {
+                    if (e.data === "") {
                         return
                     }
                     let json = JSON.parse(e.data)
@@ -125,82 +123,66 @@ export const useDirektivInstance = (url, stream, namespace, instance, apikey) =>
                 setEventSource(listener)
             }
         } else {
-            if(data === null) {
+            if (data === null) {
                 getInstance()
             }
         }
-    },[data])
+    }, [data])
 
-    React.useEffect(()=>{
+    React.useEffect(() => {
         return () => CloseEventSource(eventSource)
-    },[eventSource])
+    }, [eventSource])
 
     // getInstance returns a list of instances
     async function getInstance(...queryParameters) {
-        try {
-            // fetch instance list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}${ExtractQueryString(false, ...queryParameters)}`, {
-                headers: apikey === undefined ? {}:{"apikey": apikey}
-            })
-            if (resp.ok){
-                let json = await resp.json()
-                setData(json.instance)
-            } else {
-                return await HandleError('get instance', resp, "getInstance")
-            }
-        } catch(e) {
-            return e.message
+        // fetch instance list by default
+        let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}${ExtractQueryString(false, ...queryParameters)}`, {
+            headers: apikey === undefined ? {} : { "apikey": apikey }
+        })
+        if (resp.ok) {
+            let json = await resp.json()
+            setData(json.instance)
+            return json.instance
         }
+        throw new Error(await HandleError('get instance', resp, "getInstance"))
+
     }
 
     async function getInput(...queryParameters) {
-        try {
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/input${ExtractQueryString(false, ...queryParameters)}`, {
-                method:"GET",
-                headers: apikey === undefined ? {}:{"apikey": apikey}
+        let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/input${ExtractQueryString(false, ...queryParameters)}`, {
+            method: "GET",
+            headers: apikey === undefined ? {} : { "apikey": apikey }
 
-            })
-            if(resp.ok) {
-                let json = await resp.json()
-                return atob(json.data)
-            } else {
-                return await HandleError('get instance input', resp, 'getInstance')
-            }
-        } catch(e) {
-            return e.message
+        })
+        if (resp.ok) {
+            let json = await resp.json()
+            return atob(json.data)
         }
+        throw new Error(await HandleError('get instance input', resp, 'getInstance'))
     }
 
-    async function getOutput(...queryParameters){
-        try {
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/output${ExtractQueryString(false, ...queryParameters)}`, {
-                method:"GET",
-                headers: apikey === undefined ? {}:{"apikey": apikey}
+    async function getOutput(...queryParameters) {
+        let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/output${ExtractQueryString(false, ...queryParameters)}`, {
+            method: "GET",
+            headers: apikey === undefined ? {} : { "apikey": apikey }
 
-            })
-            if(resp.ok) {
-                let json = await resp.json()
-                return atob(json.data)
-            } else {
-                return await HandleError('get instance output', resp, 'getInstance')
-            }
-        } catch(e) {
-            return e.message
+        })
+        if (resp.ok) {
+            let json = await resp.json()
+            return atob(json.data)
         }
+        throw new Error(await HandleError('get instance output', resp, 'getInstance'))
+
     }
 
     async function cancelInstance(...queryParameters) {
-        try {
-            let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/cancel${ExtractQueryString(false, ...queryParameters)}`, {
-                method:"POST",
-                headers: apikey === undefined ? {}:{"apikey": apikey}
+        let resp = await fetch(`${url}namespaces/${namespace}/instances/${instance}/cancel${ExtractQueryString(false, ...queryParameters)}`, {
+            method: "POST",
+            headers: apikey === undefined ? {} : { "apikey": apikey }
 
-            })
-            if(!resp.ok){
-                return await HandleError('cancelling instance', resp, "cancelInstance")
-            }
-        } catch(e) {
-            return e.message
+        })
+        if (!resp.ok) {
+            throw new Error(await HandleError('cancelling instance', resp, "cancelInstance"))
         }
     }
 

--- a/src/jqplayground/index.js
+++ b/src/jqplayground/index.js
@@ -113,7 +113,6 @@ export const useDirektivJQPlayground = (url, apikey) => {
 
     return {
         data,
-        err,
         executeJQ,
         cheatSheet: cheatSheetMap,
     }

--- a/src/jqplayground/index.js
+++ b/src/jqplayground/index.js
@@ -90,29 +90,24 @@ const cheatSheetMap = [
 export const useDirektivJQPlayground = (url, apikey) => {
 
     const [data, setData] = React.useState(null)
-    const [err, setErr] = React.useState(null)
 
-
-    async function executeJQ(query, data,...queryParameters) {
-        try {
-            // fetch namespace list by default
-            let resp = await fetch(`${url}jq${ExtractQueryString(false, ...queryParameters)}`, {
-                headers: apikey === undefined ? {}:{"apikey": apikey},
-                method: "POST",
-                body: JSON.stringify({
-                    query: query,
-                    data: data,
-                })
+    async function executeJQ(query, data, ...queryParameters) {
+        // fetch namespace list by default
+        let resp = await fetch(`${url}jq${ExtractQueryString(false, ...queryParameters)}`, {
+            headers: apikey === undefined ? {} : { "apikey": apikey },
+            method: "POST",
+            body: JSON.stringify({
+                query: query,
+                data: data,
             })
-            if (resp.ok) {
-                let json = await resp.json()
-                setData(json.results)
-            } else {
-                setErr(await HandleError('execute jq', resp, 'jqPlayground'))
-            }
-        } catch(e) {
-            setErr(e.message)
+        })
+        if (!resp.ok) {
+            throw new Error((await HandleError('execute jq', resp, 'jqPlayground')))
         }
+
+        let json = await resp.json()
+        setData(json.results)
+        return json.results
     }
 
 

--- a/src/namespaces/dependencies.js
+++ b/src/namespaces/dependencies.js
@@ -7,7 +7,6 @@ const fetch = require('isomorphic-fetch')
 export const useDirektivNamespaceDependencies = (url, namespace, apikey) => {
 
     const [data, setData] = React.useState(null)
-    const [err, setErr] = React.useState(null)
     
     React.useEffect(()=>{
         if(data === null) {
@@ -16,20 +15,17 @@ export const useDirektivNamespaceDependencies = (url, namespace, apikey) => {
     },[data])
 
     async function getNamespaceDependencies(...queryParameters) {
-        try {
             // fetch namespace list by default
             let resp = await fetch(`${url}namespaces/${namespace}/dependencies${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
-            if (resp.ok) {
-                let json = await resp.json()
-                setData(json)
-            } else {
-                setErr(await HandleError('list namespace dependencies', resp, 'namespaceDependencies'))
+            if (!resp.ok) {
+                throw new Error((await HandleError('list namespace dependencies', resp, 'namespaceDependencies')))
             }
-        } catch(e) {
-            setErr(e.message)
-        }
+
+            let json = await resp.json()
+            setData(json)
+            return json
     }
 
     async function getNamespaceFunctions(){

--- a/src/namespaces/dependencies.js
+++ b/src/namespaces/dependencies.js
@@ -46,7 +46,6 @@ export const useDirektivNamespaceDependencies = (url, namespace, apikey) => {
 
     return {
         data,
-        err,
         getNamespaceDependencies,
         getNamespaceFunctions,
         getSecrets,

--- a/src/namespaces/index.js
+++ b/src/namespaces/index.js
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { json } from 'stream/consumers'
 import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 const fetch = require('isomorphic-fetch')
@@ -88,50 +89,41 @@ export const useDirektivNamespaces = (url, stream, apikey) => {
 
     // getNamespaces returns a list of namespaces
     async function getNamespaces(...queryParameters) {
-        try {
-            // fetch namespace list by default
-            let resp = await fetch(`${url}namespaces${ExtractQueryString(false, ...queryParameters)}`, {
-                headers: apikey === undefined ? {}:{"apikey": apikey}
-            })
-            if (resp.ok) {
-                let json = await resp.json()
-                setData(json.edges)
-            } else {
-                setErr(await HandleError('list namespaces', resp, 'listNamespaces'))
-            }
-        } catch(e) {
-            setErr(e.message)
+        // fetch namespace list by default
+        let resp = await fetch(`${url}namespaces${ExtractQueryString(false, ...queryParameters)}`, {
+            headers: apikey === undefined ? {} : { "apikey": apikey }
+        })
+        if (resp.ok) {
+            let json = await resp.json()
+            setData(json.edges)
+            return json.edges
+        } else {
+            throw new Error((await HandleError('list namespaces', resp, 'listNamespaces')))
         }
     }
 
     // createNamespace creates a namespace from direktiv
     async function createNamespace(namespace, ...queryParameters) {
-        try {
-            let resp = await fetch(`${url}namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
-                method: "PUT",
-                headers: apikey === undefined ? {}:{"apikey": apikey}
-            })
-            if(!resp.ok){
-                return await HandleError('create a namespace', resp, 'addNamespace')
-            } 
-        } catch(e) {
-            return e.message
+        let resp = await fetch(`${url}namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
+            method: "PUT",
+            headers: apikey === undefined ? {} : { "apikey": apikey }
+        })
+        if (!resp.ok) {
+            throw new Error(await HandleError('create a namespace', resp, 'addNamespace'))
         }
+        return await resp.json()
     }
 
     // deleteNamespace deletes a namespace from direktiv
     async function deleteNamespace(namespace, ...queryParameters) {
-        try {
-            let resp = await fetch(`${url}namespaces/${namespace}?recursive=true${ExtractQueryString(true, ...queryParameters)}`,{
-                method:"DELETE",
-                headers: apikey === undefined ? {}:{"apikey": apikey}
-            })
-            if(!resp.ok) {
-                return await HandleError('delete a namespace', resp, 'deleteNamespace')
-            }
-        } catch(e) {
-            return e.message
+        let resp = await fetch(`${url}namespaces/${namespace}?recursive=true${ExtractQueryString(true, ...queryParameters)}`, {
+            method: "DELETE",
+            headers: apikey === undefined ? {} : { "apikey": apikey }
+        })
+        if (!resp.ok) {
+            throw new Error(await HandleError('delete a namespace', resp, 'deleteNamespace'))
         }
+        return resp.json()
     }
 
     return {

--- a/src/namespaces/index.js
+++ b/src/namespaces/index.js
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { json } from 'stream/consumers'
 import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 const fetch = require('isomorphic-fetch')
@@ -123,7 +122,6 @@ export const useDirektivNamespaces = (url, stream, apikey) => {
         if (!resp.ok) {
             throw new Error(await HandleError('delete a namespace', resp, 'deleteNamespace'))
         }
-        return resp.json()
     }
 
     return {

--- a/src/namespaces/logs.js
+++ b/src/namespaces/logs.js
@@ -57,19 +57,16 @@ export const useDirektivNamespaceLogs = (url, stream, namespace, apikey) => {
 
     // getNamespaces returns a list of namespaces
     async function getNamespaceLogs(...queryParameters) {
-        try {
-            // fetch namespace list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/logs${ExtractQueryString(false, ...queryParameters)}`, {
-                headers: apikey === undefined ? {}:{"apikey": apikey}
-            })
-            if (resp.ok) {
-                let json = await resp.json()
-                setData(json.edges)
-            } else {
-                setErr(await HandleError('list namespace logs', resp, 'namespaceLogs'))
-            }
-        } catch(e) {
-            setErr(e.message)
+        // fetch namespace list by default
+        let resp = await fetch(`${url}namespaces/${namespace}/logs${ExtractQueryString(false, ...queryParameters)}`, {
+            headers: apikey === undefined ? {} : { "apikey": apikey }
+        })
+        if (resp.ok) {
+            let json = await resp.json()
+            setData(json.edges)
+            return json.edges
+        } else {
+            throw new Error((await HandleError('list namespace logs', resp, 'namespaceLogs')))
         }
     }
 

--- a/src/namespaces/metrics.js
+++ b/src/namespaces/metrics.js
@@ -56,7 +56,6 @@ export const useDirektivNamespaceMetrics = (url, namespace, apikey) => {
     }
 
     return {
-        err,
         getInvoked,
         getSuccessful,
         getFailed,

--- a/src/namespaces/metrics.js
+++ b/src/namespaces/metrics.js
@@ -10,65 +10,48 @@ import { HandleError, ExtractQueryString } from '../util'
       - apikey to provide authentication of an apikey
 */
 export const useDirektivNamespaceMetrics = (url, namespace, apikey) => {
-    const [err, setErr] = React.useState(null)
 
-    async function getInvoked(...queryParameters){
-        try {
-            let resp = await fetch(`${url}namespaces/${namespace}/metrics/invoked${ExtractQueryString(false, ...queryParameters)}`,{
-                headers: apikey === undefined ? {}:{"apikey": apikey}
-            })
-            if(resp.ok){
-                return await resp.json()
-            } else {
-                setErr(await HandleError('get invoked metrics', resp, 'getMetrics'))
-            }
-        } catch(e){
-            setErr(e.message)
+    async function getInvoked(...queryParameters) {
+        let resp = await fetch(`${url}namespaces/${namespace}/metrics/invoked${ExtractQueryString(false, ...queryParameters)}`, {
+            headers: apikey === undefined ? {} : { "apikey": apikey }
+        })
+        if (resp.ok) {
+            return await resp.json()
+        } else {
+            throw new Error((await HandleError('get invoked metrics', resp, 'getMetrics')))
         }
     }
 
-    async function getSuccessful(...queryParameters){
-        try {
-            let resp = await fetch(`${url}namespaces/${namespace}/metrics/successful${ExtractQueryString(false, ...queryParameters)}`,{
-                headers: apikey === undefined ? {}:{"apikey": apikey}
-            })
-            if(resp.ok){
-                return await resp.json()
-            } else {
-                setErr(await HandleError('get successful metrics', resp, 'getMetrics'))
-            }
-        } catch(e){
-            setErr(e.message)
+    async function getSuccessful(...queryParameters) {
+        let resp = await fetch(`${url}namespaces/${namespace}/metrics/successful${ExtractQueryString(false, ...queryParameters)}`, {
+            headers: apikey === undefined ? {} : { "apikey": apikey }
+        })
+        if (resp.ok) {
+            return await resp.json()
+        } else {
+            throw new Error((await HandleError('get successful metrics', resp, 'getMetrics')))
         }
     }
 
     async function getFailed(...queryParameters) {
-        try {
-            let resp = await fetch(`${url}namespaces/${namespace}/metrics/failed${ExtractQueryString(false, ...queryParameters)}`,{
-                headers: apikey === undefined ? {}:{"apikey": apikey}
-            })
-            if(resp.ok){
-                return await resp.json()
-            } else {
-                setErr(await HandleError('get failed metrics', resp, 'getMetrics'))
-            }
-        } catch(e){
-            setErr(e.message)
+        let resp = await fetch(`${url}namespaces/${namespace}/metrics/failed${ExtractQueryString(false, ...queryParameters)}`, {
+            headers: apikey === undefined ? {} : { "apikey": apikey }
+        })
+        if (resp.ok) {
+            return await resp.json()
+        } else {
+            throw new Error(await HandleError('get failed metrics', resp, 'getMetrics'))
         }
     }
 
     async function getMilliseconds(...queryParameters) {
-        try {
-            let resp = await fetch(`${url}namespaces/${namespace}/metrics/milliseconds${ExtractQueryString(false, ...queryParameters)}`,{
-                headers: apikey === undefined ? {}:{"apikey": apikey}
-            })
-            if(resp.ok){
-                return await resp.json()
-            } else {
-                setErr(await HandleError('get millisecond metrics', resp, 'getMetrics'))
-            }
-        } catch(e){
-            setErr(e.message)
+        let resp = await fetch(`${url}namespaces/${namespace}/metrics/milliseconds${ExtractQueryString(false, ...queryParameters)}`, {
+            headers: apikey === undefined ? {} : { "apikey": apikey }
+        })
+        if (resp.ok) {
+            return await resp.json()
+        } else {
+            throw new Error((await HandleError('get millisecond metrics', resp, 'getMetrics')))
         }
     }
 

--- a/src/namespaces/variables.js
+++ b/src/namespaces/variables.js
@@ -57,65 +57,49 @@ export const useDirektivNamespaceVariables = (url, stream, namespace, apikey) =>
 
     // getNamespaces returns a list of namespaces
     async function getNamespaceVariables(...queryParameters) {
-        try {
-            // fetch namespace list by default
-            let resp = await fetch(`${url}namespaces/${namespace}/vars${ExtractQueryString(false, ...queryParameters)}`, {
-                headers: apikey === undefined ? {}:{"apikey": apikey}
-            })
-            if (resp.ok) {
-                let json = await resp.json()
-                setData(json.variables.edges)
-            } else {
-                setErr(await HandleError('list namespace variables', resp, 'namespaceVars'))
-            }
-        } catch(e) {
-            setErr(e.message)
+        // fetch namespace list by default
+        let resp = await fetch(`${url}namespaces/${namespace}/vars${ExtractQueryString(false, ...queryParameters)}`, {
+            headers: apikey === undefined ? {} : { "apikey": apikey }
+        })
+        if (resp.ok) {
+            let json = await resp.json()
+            setData(json.variables.edges)
+        } else {
+            throw new Error((await HandleError('list namespace variables', resp, 'namespaceVars')))
         }
     }
 
     async function getNamespaceVariable(name, ...queryParameters) {
-        try {
-            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, ...queryParameters)}`, {})
-            if(resp.ok) {
-                return {data: await resp.text(), contentType: resp.headers.get("Content-Type")}
-            } else {
-                return await HandleError('get variable', resp, 'getNamespaceVariable')
-            }
-        } catch(e) {
-            return e.message
+        let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, ...queryParameters)}`, {})
+        if (resp.ok) {
+            return { data: await resp.text(), contentType: resp.headers.get("Content-Type") }
+        } else {
+            throw new Error(await HandleError('get variable', resp, 'getNamespaceVariable'))
         }
     }
 
-    async function deleteNamespaceVariable(name,...queryParameters) {
-        try {
-            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, ...queryParameters)}`,{
-                method: "DELETE"
-            })
-            if(!resp.ok) {
-                return await HandleError('delete variable', resp, 'deleteNamespaceVariable')
-            }
-        } catch(e) {
-            return e.message
+    async function deleteNamespaceVariable(name, ...queryParameters) {
+        let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, ...queryParameters)}`, {
+            method: "DELETE"
+        })
+        if (!resp.ok) {
+            throw new Error(await HandleError('delete variable', resp, 'deleteNamespaceVariable'))
         }
     }
 
-    async function setNamespaceVariable(name, val, mimeType,...queryParameters) {
-        if(mimeType === undefined){
+    async function setNamespaceVariable(name, val, mimeType, ...queryParameters) {
+        if (mimeType === undefined) {
             mimeType = "application/json"
         }
-        try {
-            let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, ...queryParameters)}`, {
-                method: "PUT",
-                body: val,
-                headers: {
-                    "Content-type": mimeType,
-                },
-            })
-            if (!resp.ok) {
-               return await HandleError('set variable', resp, 'setNamespaceVariable')
-            }
-        } catch(e) {
-            return e.message
+        let resp = await fetch(`${url}namespaces/${namespace}/vars/${name}${ExtractQueryString(false, ...queryParameters)}`, {
+            method: "PUT",
+            body: val,
+            headers: {
+                "Content-type": mimeType,
+            },
+        })
+        if (!resp.ok) {
+            throw new Error(await HandleError('set variable', resp, 'setNamespaceVariable'))
         }
     }
 

--- a/src/nodes/index.js
+++ b/src/nodes/index.js
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { json } from 'stream/consumers'
 import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 const fetch = require('isomorphic-fetch')
@@ -449,8 +448,6 @@ export const useDirektivNodes = (url, stream, namespace, path, apikey, orderFiel
             if(!resp.ok){
               throw new Error( await HandleError('delete node', resp, 'deleteNode'))
             }
-
-            return await resp.json()
     }
 
     async function renameNode(fpath, oldname, newname, ...queryParameters) {

--- a/src/registries/global-private.js
+++ b/src/registries/global-private.js
@@ -60,7 +60,6 @@ export const useDirektivGlobalPrivateRegistries = (url, apikey) => {
 
     return {
         data,
-        err,
         createRegistry,
         deleteRegistry,
         getRegistries

--- a/src/registries/global-private.js
+++ b/src/registries/global-private.js
@@ -11,7 +11,6 @@ const fetch = require('isomorphic-fetch')
 export const useDirektivGlobalPrivateRegistries = (url, apikey) => {
 
     const [data, setData] = React.useState(null)
-    const [err, setErr] = React.useState(null)
 
     React.useEffect(()=>{
         if(data === null) {
@@ -21,51 +20,42 @@ export const useDirektivGlobalPrivateRegistries = (url, apikey) => {
 
     // getGlobalPrivateRegistries returns a list of registries
     async function getRegistries(...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions/registries/private${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
                 let json = await resp.json()
                 setData(json.registries)
+                return json.registries
             } else {
-                setErr(await HandleError('list registries', resp, 'listGlobalPrivateRegistries'))
+                throw new Error(await HandleError('list registries', resp, 'listGlobalPrivateRegistries'))
             }
-        } catch(e) {
-            setErr(e.message)
-        }
-    }
+     }
 
     async function createRegistry(key, val,...queryParameters){
-        try {
-            let resp = await fetch(`${url}functions/registries/private${ExtractQueryString(false, ...queryParameters)}`, {
-                method: "POST",
-                body: JSON.stringify({data:val, reg: key})
-            })
-            if(!resp.ok){
-                return await HandleError('create registry', resp, 'createRegistry')
-
-            }
-        } catch(e) {
-            setErr(e.message)
+        let resp = await fetch(`${url}functions/registries/private${ExtractQueryString(false, ...queryParameters)}`, {
+            method: "POST",
+            body: JSON.stringify({data:val, reg: key})
+        })
+        if(!resp.ok){
+            throw new Error( await HandleError('create registry', resp, 'createRegistry'))
         }
+
+        return await resp.json()
     }
 
     async function deleteRegistry(key,...queryParameters){
-        try {
-            let resp = await fetch(`${url}functions/registries/private${ExtractQueryString(false, ...queryParameters)}`, {
-                method: "DELETE",
-                body: JSON.stringify({
-                    reg: key
-                })
+        let resp = await fetch(`${url}functions/registries/private${ExtractQueryString(false, ...queryParameters)}`, {
+            method: "DELETE",
+            body: JSON.stringify({
+                reg: key
             })
-            if (!resp.ok) {
-                return await HandleError('delete registry', resp, 'deleteRegistry')
-
-            }
-        } catch (e) {
-            setErr(e.message)
+        })
+        if (!resp.ok) {
+            throw new Error( await HandleError('delete registry', resp, 'deleteRegistry'))
         }
+
+        return await resp.json()
     }
 
     return {

--- a/src/registries/global.js
+++ b/src/registries/global.js
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { json } from 'stream/consumers'
 import {  HandleError, ExtractQueryString } from '../util'
 const fetch = require('isomorphic-fetch')
 
@@ -61,7 +60,6 @@ export const useDirektivGlobalRegistries = (url, apikey) => {
 
     return {
         data,
-        err,
         createRegistry,
         deleteRegistry,
         getRegistries

--- a/src/registries/global.js
+++ b/src/registries/global.js
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { json } from 'stream/consumers'
 import {  HandleError, ExtractQueryString } from '../util'
 const fetch = require('isomorphic-fetch')
 
@@ -11,7 +12,6 @@ const fetch = require('isomorphic-fetch')
 export const useDirektivGlobalRegistries = (url, apikey) => {
 
     const [data, setData] = React.useState(null)
-    const [err, setErr] = React.useState(null)
 
     React.useEffect(()=>{
         if(data === null) {
@@ -21,38 +21,31 @@ export const useDirektivGlobalRegistries = (url, apikey) => {
 
     // getGlobalRegistries returns a list of registries
     async function getRegistries(...queryParameters) {
-        try {
-            let resp = await fetch(`${url}functions/registries/global${ExtractQueryString(false, ...queryParameters)}`, {
-                headers: apikey === undefined ? {}:{"apikey": apikey}
-            })
-            if (resp.ok) {
-                let json = await resp.json()
-                setData(json.registries)
-            } else {
-                setErr(await HandleError('list registries', resp, 'listGlobalRegistries'))
-            }
-        } catch(e) {
-            setErr(e.message)
+        let resp = await fetch(`${url}functions/registries/global${ExtractQueryString(false, ...queryParameters)}`, {
+            headers: apikey === undefined ? {}:{"apikey": apikey}
+        })
+        if (resp.ok) {
+            let json = await resp.json()
+            setData(json.registries)
+            return json.registries
+        } else {
+            throw new Error(await HandleError('list registries', resp, 'listGlobalRegistries'))
         }
     }
 
     async function createRegistry(key, val,...queryParameters){
-        try {
             let resp = await fetch(`${url}functions/registries/global${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "POST",
                 body: JSON.stringify({data:val, reg: key})
             })
             if(!resp.ok){
-                return await HandleError('create registry', resp, 'createRegistry')
+                throw new Error( await HandleError('create registry', resp, 'createRegistry'))
 
             }
-        } catch(e) {
-            setErr(e.message)
-        }
+            return await resp.json()
     }
 
     async function deleteRegistry(key, ...queryParameters){
-        try {
             let resp = await fetch(`${url}functions/registries/global${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "DELETE",
                 body: JSON.stringify({
@@ -60,12 +53,10 @@ export const useDirektivGlobalRegistries = (url, apikey) => {
                 })
             })
             if (!resp.ok) {
-                return await HandleError('delete registry', resp, 'deleteRegistry')
+                throw new Error( await HandleError('delete registry', resp, 'deleteRegistry'))
 
             }
-        } catch (e) {
-            setErr(e.message)
-        }
+            return await resp.json()
     }
 
     return {

--- a/src/registries/index.js
+++ b/src/registries/index.js
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { json } from 'stream/consumers'
 import {  HandleError, ExtractQueryString } from '../util'
 const fetch = require("isomorphic-fetch")
 
@@ -63,7 +62,6 @@ export const useDirektivRegistries = (url, namespace, apikey) => {
 
     return {
         data,
-        err,
         createRegistry,
         deleteRegistry,
         getRegistries

--- a/src/registries/index.js
+++ b/src/registries/index.js
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { json } from 'stream/consumers'
 import {  HandleError, ExtractQueryString } from '../util'
 const fetch = require("isomorphic-fetch")
 
@@ -15,7 +16,6 @@ const fetch = require("isomorphic-fetch")
 export const useDirektivRegistries = (url, namespace, apikey) => {
 
     const [data, setData] = React.useState(null)
-    const [err, setErr] = React.useState(null)
 
     React.useEffect(()=>{
         if(data === null) {
@@ -25,37 +25,30 @@ export const useDirektivRegistries = (url, namespace, apikey) => {
 
     // getRegistries returns a list of registries
     async function getRegistries(...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions/registries/namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
                 let json = await resp.json()
                 setData(json.registries)
+                return await json.registries
             } else {
-                setErr(await HandleError('list registries', resp, 'listRegistries'))
+                throw new Error(await HandleError('list registries', resp, 'listRegistries'))
             }
-        } catch(e) {
-            setErr(e.message)
-        }
     }
 
     async function createRegistry(key, val,...queryParameters){
-        try {
             let resp = await fetch(`${url}functions/registries/namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "POST",
                 body: JSON.stringify({data:val, reg: key})
             })
             if(!resp.ok){
-                return await HandleError('create registry', resp, 'createRegistry')
+                throw new Error( await HandleError('create registry', resp, 'createRegistry'))
             }
-        } catch(e) {
-            return e.message
-        }
+            return await resp.json()
     }
 
     async function deleteRegistry(key,...queryParameters){
-        try {
             let resp = await fetch(`${url}functions/registries/namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "DELETE",
                 body: JSON.stringify({
@@ -63,11 +56,9 @@ export const useDirektivRegistries = (url, namespace, apikey) => {
                 })
             })
             if (!resp.ok) {
-                return await HandleError('delete registry', resp, 'deleteRegistry')
+                throw new Error( await HandleError('delete registry', resp, 'deleteRegistry'))
             }
-        } catch (e) {
-            return e.message
-        }
+            return await resp.json()
     }
 
     return {

--- a/src/secrets/index.js
+++ b/src/secrets/index.js
@@ -55,7 +55,6 @@ export const useDirektivSecrets = (url, namespace, apikey) => {
 
     return {
         data,
-        err,
         createSecret,
         deleteSecret,
         getSecrets

--- a/src/secrets/index.js
+++ b/src/secrets/index.js
@@ -11,7 +11,6 @@ const fetch = require('isomorphic-fetch')
 */
 export const useDirektivSecrets = (url, namespace, apikey) => {
     const [data, setData] = React.useState(null)
-    const [err, setErr] = React.useState(null)
 
     React.useEffect(()=>{
         if(data === null) {
@@ -21,46 +20,36 @@ export const useDirektivSecrets = (url, namespace, apikey) => {
 
     // getSecrets returns a list of registries
     async function getSecrets(...queryParameters) {
-        try {
             let resp = await fetch(`${url}namespaces/${namespace}/secrets${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
             })
             if (resp.ok) {
                 let json = await resp.json()
                 setData(json.secrets.edges)
+                return json.secrets.edges
             } else {
-                setErr(await HandleError('list secrets', resp, 'listSecrets'))
+                throw new Error(await HandleError('list secrets', resp, 'listSecrets'))
             }
-        } catch(e) {
-            setErr(e.message)
-        }
     }
 
     async function createSecret(name,value,...queryParameters) {
-        try {
             let resp = await fetch(`${url}namespaces/${namespace}/secrets/${name}${ExtractQueryString(false, ...queryParameters)}`,{
                 method: "PUT",
                 body: value
             })
             if(!resp.ok){
-                return await HandleError('create secret', resp, 'createSecret')
+                throw new Error( await HandleError('create secret', resp, 'createSecret'))
             }
-        } catch(e) {
-            return e.message
-        }
     }
 
     async function deleteSecret(name,...queryParameters) {
-        try {
             let resp = await fetch(`${url}namespaces/${namespace}/secrets/${name}${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "DELETE"
             })
             if (!resp.ok) {
-                return await HandleError('delete secret', resp, 'deleteSecret')
+                throw new Error( await HandleError('delete secret', resp, 'deleteSecret'))
             }
-        } catch (e) {
-            return e.message
-        }
+            return await resp.json()
     }
 
 

--- a/src/services/global.js
+++ b/src/services/global.js
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { json } from 'stream/consumers'
 import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 const fetch = require('isomorphic-fetch')
@@ -263,7 +262,6 @@ export const useDirektivGlobalService = (url, service, apikey) => {
             if (!resp.ok) {
                 throw new Error( await HandleError('create global service revision', resp, 'createRevision'))
             }
-            return await resp.json()
     }
 
     async function deleteGlobalServiceRevision(rev,...queryParameters){
@@ -274,7 +272,6 @@ export const useDirektivGlobalService = (url, service, apikey) => {
             if(!resp.ok){
                 throw new Error( await HandleError('delete global service revision', resp, 'deleteRevision'))
             }
-            return await resp.json()
     }
 
     async function getServiceConfig(...queryParameters) {
@@ -455,7 +452,6 @@ export const useDirektivGlobalServices = (url, stream, apikey) => {
             if (!resp.ok) {
                 throw new Error( await HandleError('create global service', resp, 'createService'))
             }
-            return await resp.json()
     }
 
     async function deleteGlobalService(name,...queryParameters) {
@@ -467,7 +463,6 @@ export const useDirektivGlobalServices = (url, stream, apikey) => {
                 throw new Error( await HandleError('delete global service', resp, 'deleteService'))
             }
 
-            return await resp.json()
     }
 
 

--- a/src/services/global.js
+++ b/src/services/global.js
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { json } from 'stream/consumers'
 import { CloseEventSource, HandleError, ExtractQueryString } from '../util'
 const {EventSourcePolyfill} = require('event-source-polyfill')
 const fetch = require('isomorphic-fetch')
@@ -248,7 +249,6 @@ export const useDirektivGlobalService = (url, service, apikey) => {
     },[eventSource, trafficSource])
 
     async function createGlobalServiceRevision(image, minScale, size, cmd, traffic,...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions/${service}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "POST",
@@ -261,29 +261,23 @@ export const useDirektivGlobalService = (url, service, apikey) => {
                 })
             })
             if (!resp.ok) {
-                return await HandleError('create global service revision', resp, 'createRevision')
+                throw new Error( await HandleError('create global service revision', resp, 'createRevision'))
             }
-        } catch(e){
-            return e.message
-        }
+            return await resp.json()
     }
 
     async function deleteGlobalServiceRevision(rev,...queryParameters){
-        try {
             let resp = await fetch(`${url}functions/${service}/revisions/${rev}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "DELETE"
             })
             if(!resp.ok){
-                return await HandleError('delete global service revision', resp, 'deleteRevision')
+                throw new Error( await HandleError('delete global service revision', resp, 'deleteRevision'))
             }
-        } catch(e){
-            return e.message
-        }
+            return await resp.json()
     }
 
     async function getServiceConfig(...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions/${service}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
@@ -291,16 +285,13 @@ export const useDirektivGlobalService = (url, service, apikey) => {
             if (resp.ok) {
                 let json = await resp.json()
                 setConfig(json.config)
+                return json.config
             } else {
-                setErr(await HandleError('get namespace service', resp, 'getService'))
+                throw new Error(await HandleError('get namespace service', resp, 'getService'))
             }
-        } catch(e){
-            setErr(e.message)
-        }
     }
 
     async function setGlobalServiceRevisionTraffic(rev1, rev1value, rev2, rev2value,...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions/${service}${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "PATCH",
                 headers: apikey === undefined ? {}:{"apikey": apikey},
@@ -313,11 +304,10 @@ export const useDirektivGlobalService = (url, service, apikey) => {
                 }]})
             })
             if(!resp.ok){
-                return await HandleError('update traffic global service', resp, 'updateTraffic')
+                throw new Error( await HandleError('update traffic global service', resp, 'updateTraffic'))
             }
-        } catch(e){
-            return e.message
-        }
+
+            return resp.json()
     }
 
     return {
@@ -423,7 +413,6 @@ export const useDirektivGlobalServices = (url, stream, apikey) => {
 
 
     async function getConfig(...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
@@ -431,16 +420,13 @@ export const useDirektivGlobalServices = (url, stream, apikey) => {
             if (resp.ok) {
                 let json = await resp.json()
                 setConfig(json.config)
+                return json.config
             } else {
-                setErr(await HandleError('get namespace service', resp, 'listServices'))
+                throw new Error(await HandleError('get namespace service', resp, 'listServices'))
             }
-        } catch(e){
-            setErr(e.message)
-        }
     }
 
     async function getGlobalServices(...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
@@ -448,16 +434,13 @@ export const useDirektivGlobalServices = (url, stream, apikey) => {
             if (resp.ok) {
                 let json = await resp.json()
                 setData(json.functions)
+                return json.functions
             } else {
-                setErr(await HandleError('get global services', resp, 'listServices'))
+                throw new Error(await HandleError('get global services', resp, 'listServices'))
             }
-        } catch(e){
-            setErr(e.message)
-        }
     }
 
     async function createGlobalService(name, image, minScale, size, cmd,...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "POST",
@@ -470,25 +453,21 @@ export const useDirektivGlobalServices = (url, stream, apikey) => {
                 })
             })
             if (!resp.ok) {
-                return await HandleError('create global service', resp, 'createService')
+                throw new Error( await HandleError('create global service', resp, 'createService'))
             }
-        } catch(e){
-            return e.message
-        }
+            return await resp.json()
     }
 
     async function deleteGlobalService(name,...queryParameters) {
-        try {
             let resp = await fetch(`${url}/functions/${name}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "DELETE"
             })
             if(!resp.ok) {
-                return await HandleError('delete global service', resp, 'deleteService')
+                throw new Error( await HandleError('delete global service', resp, 'deleteService'))
             }
-        } catch(e) {
-            return e.message
-        }
+
+            return await resp.json()
     }
 
 

--- a/src/services/namespace.js
+++ b/src/services/namespace.js
@@ -250,7 +250,6 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
     },[eventSource, trafficSource])
 
     async function getNamespaceServiceConfig(...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
@@ -258,16 +257,14 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
             if (resp.ok) {
                 let json = await resp.json()
                 setConfig(json.config)
+                return json.config
             } else {
-                setErr(await HandleError('get namespace service', resp, 'getService'))
+                throw new Error(await HandleError('get namespace service', resp, 'getService'))
             }
-        } catch(e){
-            setErr(e.message)
-        }
+
     }
 
     async function createNamespaceServiceRevision(image, minScale, size, cmd, traffic,...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "POST",
@@ -280,29 +277,25 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
                 })
             })
             if (!resp.ok) {
-                return await HandleError('create namespace service revision', resp, 'createRevision')
+                throw new Error(await HandleError('create namespace service revision', resp, 'createRevision'))
             }
-        } catch(e){
-            return e.message
-        }
+
+            return await resp.json()
     }
 
     async function deleteNamespaceServiceRevision(rev,...queryParameters){
-        try {
             let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${service}/revisions/${rev}${ExtractQueryString(false, ...queryParameters)}`, {
                 method: "DELETE",
                 headers: apikey === undefined ? {}:{"apikey": apikey},
             })
             if(!resp.ok){
-                return await HandleError('delete namespace service revision', resp, 'deleteRevision')
+                throw new Error( await HandleError('delete namespace service revision', resp, 'deleteRevision'))
             }
-        } catch(e){
-            return e.message
-        }
+
+            return await resp.json()
     }
 
     async function setNamespaceServiceRevisionTraffic(rev1, rev1value, rev2, rev2value,...queryParameters) {
-        try {
             let trafficarr = []
             if(rev1 !== "") {
                 trafficarr.push({
@@ -321,11 +314,10 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
                 body: JSON.stringify({values:trafficarr})
             })
             if(!resp.ok){
-                return await HandleError('update traffic namespace service', resp, 'updateTraffic')
+                throw new Error( await HandleError('update traffic namespace service', resp, 'updateTraffic'))
             }
-        } catch(e){
-            return e.message
-        }
+
+            return await resp.json()
     }
 
     return {
@@ -428,7 +420,6 @@ export const useDirektivNamespaceServices = (url, stream, namespace, apikey) => 
 
 
     async function getNamespaceServices(...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions/namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
@@ -436,16 +427,13 @@ export const useDirektivNamespaceServices = (url, stream, namespace, apikey) => 
             if (resp.ok) {
                 let json = await resp.json()
                 setData(json.functions)
+                return json.functions
             } else {
-                setErr(await HandleError('get namespace service', resp, 'listServices'))
+                throw new Error(await HandleError('get namespace service', resp, 'listServices'))
             }
-        } catch(e){
-            setErr(e.message)
-        }
     }
 
     async function getNamespaceConfig(...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions/namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
@@ -453,16 +441,13 @@ export const useDirektivNamespaceServices = (url, stream, namespace, apikey) => 
             if (resp.ok) {
                 let json = await resp.json()
                 setConfig(json.config)
+                return json.config
             } else {
-                setErr(await HandleError('get namespace service', resp, 'listServices'))
+                throw new Error(await HandleError('get namespace service', resp, 'listServices'))
             }
-        } catch(e){
-            setErr(e.message)
-        }
     }
 
     async function createNamespaceService(name, image, minScale, size, cmd,...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions/namespaces/${namespace}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "POST",
@@ -475,25 +460,23 @@ export const useDirektivNamespaceServices = (url, stream, namespace, apikey) => 
                 })
             })
             if (!resp.ok) {
-                return await HandleError('create namespace service', resp, 'createService')
+                throw new Error( await HandleError('create namespace service', resp, 'createService'))
             }
-        } catch(e){
-            return e.message
-        }
+
+            return resp.json()
+
     }
 
     async function deleteNamespaceService(name,...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions/namespaces/${namespace}/function/${name}${ExtractQueryString(false, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "DELETE"
             })
             if(!resp.ok) {
-                return await HandleError('delete namespace service', resp, 'deleteService')
+                throw new Error( await HandleError('delete namespace service', resp, 'deleteService'))
             }
-        } catch(e) {
-            return e.message
-        }
+
+            return await resp.json()
     }
 
 

--- a/src/services/namespace.js
+++ b/src/services/namespace.js
@@ -279,8 +279,6 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
             if (!resp.ok) {
                 throw new Error(await HandleError('create namespace service revision', resp, 'createRevision'))
             }
-
-            return await resp.json()
     }
 
     async function deleteNamespaceServiceRevision(rev,...queryParameters){
@@ -291,8 +289,6 @@ export const useDirektivNamespaceService = (url, namespace, service, apikey) => 
             if(!resp.ok){
                 throw new Error( await HandleError('delete namespace service revision', resp, 'deleteRevision'))
             }
-
-            return await resp.json()
     }
 
     async function setNamespaceServiceRevisionTraffic(rev1, rev1value, rev2, rev2value,...queryParameters) {
@@ -462,9 +458,6 @@ export const useDirektivNamespaceServices = (url, stream, namespace, apikey) => 
             if (!resp.ok) {
                 throw new Error( await HandleError('create namespace service', resp, 'createService'))
             }
-
-            return resp.json()
-
     }
 
     async function deleteNamespaceService(name,...queryParameters) {
@@ -475,8 +468,6 @@ export const useDirektivNamespaceServices = (url, stream, namespace, apikey) => 
             if(!resp.ok) {
                 throw new Error( await HandleError('delete namespace service', resp, 'deleteService'))
             }
-
-            return await resp.json()
     }
 
 

--- a/src/services/workflow.js
+++ b/src/services/workflow.js
@@ -310,7 +310,6 @@ export const useDirektivWorkflowServices = (url, stream, namespace, path, apikey
 
 
     async function getWorkflowServices(...queryParameters) {
-        try {
             let resp = await fetch(`${url}functions/namespaces/${namespace}/tree/${path}?op=services${ExtractQueryString(true, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey},
                 method: "GET"
@@ -318,12 +317,10 @@ export const useDirektivWorkflowServices = (url, stream, namespace, path, apikey
             if (resp.ok) {
                 let json = await resp.json()
                 setData(json)
+                return json
             } else {
-                setErr(await HandleError('get workflow services', resp, 'listServices'))
+                throw new Error(await HandleError('get workflow services', resp, 'listServices'))
             }
-        } catch(e){
-            setErr(e.message)
-        }
     }
 
     return {

--- a/src/workflow/index.js
+++ b/src/workflow/index.js
@@ -56,7 +56,6 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
 
 
     async function getWorkflow(...queryParameters) {
-        try {
             let uri = `${url}namespaces/${namespace}/tree/${path}`
  
             let resp = await fetch(`${uri}/${ExtractQueryString(false, ...queryParameters)}`, {
@@ -65,12 +64,10 @@ export const useDirektivWorkflow = (url, stream, namespace, path, apikey) => {
             if (resp.ok) {
                 let json = await resp.json()
                 setData(json)
+                return json
             } else {
-                setErr(await HandleError('get node', resp, 'listNodes'))
+                throw new Error(await HandleError('get node', resp, 'listNodes'))
             }
-        } catch(e){
-            setErr(e.message)
-        }
     }
 
     async function getWorkflowSankeyMetrics(rev,...queryParameters) {

--- a/src/workflow/logs.js
+++ b/src/workflow/logs.js
@@ -58,7 +58,6 @@ export const useDirektivWorkflowLogs = (url, stream, namespace, path, apikey) =>
 
     // getWorkflowLogs returns a list of workflow logs
     async function getWorkflowLogs(...queryParameters) {
-        try {
             // fetch namespace list by default
             let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=logs${ExtractQueryString(true, ...queryParameters)}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
@@ -66,12 +65,10 @@ export const useDirektivWorkflowLogs = (url, stream, namespace, path, apikey) =>
             if (resp.ok) {
                 let json = await resp.json()
                 setData(json.edges)
+                return json.edges
             } else {
-                setErr(await HandleError('list namespace logs', resp, 'namespaceLogs'))
+                throw new Error(await HandleError('list namespace logs', resp, 'namespaceLogs'))
             }
-        } catch(e) {
-            setErr(e.message)
-        }
     }
 
 

--- a/src/workflow/variables.js
+++ b/src/workflow/variables.js
@@ -56,7 +56,6 @@ export const useDirektivWorkflowVariables = (url, stream, namespace, path, apike
 
 
     async function getWorkflowVariables(...queryParameters) {
-        try {
             let uri = `${url}namespaces/${namespace}/tree/${path}?op=vars${ExtractQueryString(true, ...queryParameters)}` 
             let resp = await fetch(`${uri}`, {
                 headers: apikey === undefined ? {}:{"apikey": apikey}
@@ -64,19 +63,16 @@ export const useDirektivWorkflowVariables = (url, stream, namespace, path, apike
             if (resp.ok) {
                 let json = await resp.json()
                 setData(json.variables.edges)
+                return json.variables.edges
             } else {
-                setErr(await HandleError('get node', resp, 'listNodes'))
+                throw new Error(await HandleError('get node', resp, 'listNodes'))
             }
-        } catch(e){
-            setErr(e.message)
-        }
     }
 
     async function setWorkflowVariable(name, val, mimeType,...queryParameters) {
         if(mimeType === undefined){
             mimeType = "application/json"
         }
-        try {
             let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=set-var&var=${name}${ExtractQueryString(true, ...queryParameters)}`, {
                 method: "PUT",
                 body: val,
@@ -85,37 +81,30 @@ export const useDirektivWorkflowVariables = (url, stream, namespace, path, apike
                 },
             })
             if (!resp.ok) {
-               return await HandleError('set variable', resp, 'setWorkflowVariable')
+                throw new Error(HandleError('set variable', resp, 'setWorkflowVariable'))
             }
-        } catch(e) {
-            return e.message
-        }
+
+            return await resp.json()
     }
 
     async function getWorkflowVariable(name,...queryParameters) {
-        try {
             let resp = await fetch(`${url}/namespaces/${namespace}/tree/${path}?op=var&var=${name}${ExtractQueryString(true, ...queryParameters)}`, {})
             if(resp.ok) {
                 return {data: await resp.text(), contentType: resp.headers.get("Content-Type")}
             } else {
-                return await HandleError('get variable', resp, 'getWorkflowVariable')
+                throw new Error( await HandleError('get variable', resp, 'getWorkflowVariable'))
             }
-        } catch(e) {
-            return e.message
-        }
     }
 
     async function deleteWorkflowVariable(name,...queryParameters) {
-        try {
             let resp = await fetch(`${url}namespaces/${namespace}/tree/${path}?op=delete-var&var=${name}${ExtractQueryString(true, ...queryParameters)}`,{
                 method: "DELETE"
             })
             if(!resp.ok) {
-                return await HandleError('delete variable', resp, 'deleteWorkflowVariable')
+                throw new Error( await HandleError('delete variable', resp, 'deleteWorkflowVariable'))
             }
-        } catch(e) {
-            return e.message
-        }
+
+            return await resp.json()
     }
 
     return {

--- a/src/workflow/variables.js
+++ b/src/workflow/variables.js
@@ -81,7 +81,7 @@ export const useDirektivWorkflowVariables = (url, stream, namespace, path, apike
                 },
             })
             if (!resp.ok) {
-                throw new Error(HandleError('set variable', resp, 'setWorkflowVariable'))
+                throw new Error(await HandleError('set variable', resp, 'setWorkflowVariable'))
             }
 
             return await resp.json()
@@ -104,7 +104,6 @@ export const useDirektivWorkflowVariables = (url, stream, namespace, path, apike
                 throw new Error( await HandleError('delete variable', resp, 'deleteWorkflowVariable'))
             }
 
-            return await resp.json()
     }
 
     return {


### PR DESCRIPTION
## Description

Basically instead of returning errors like functions did before, functions will now return the response, and throw any errors that happen. This way you can have both resp and error on ui side and also hooks no longer share a error state.

## Purpose

- [X] Bug fix
- [X] New feature
- [ ] Other

## How was this tested? (if applicable)

Please describe how the proposed changes have been tested, and the outcome of the tests.

## Test Platform Details (if applicable)

**Operating system:** OSX/Windows 10/Ubuntu 20.04/etc.

**CLI version:**

**Hypervisors/Platforms (if applicable):** qemu/hyper-v/google cloud platform/vmware workstation/etc

**Kernel version (if applicable):**

## Checklist

- [ ] Code is commented
- [ ] Unit test coverage encompasses new code
- [ ] Existing unit tests pass with these changes
- [ ] PR is signed
